### PR TITLE
SC-3625 www docs adjustments for token/rec rename

### DIFF
--- a/docs/monitoring/chef-recipe.md
+++ b/docs/monitoring/chef-recipe.md
@@ -22,10 +22,10 @@ if node.spm[:token]  # Will only run if a SPM token is present.
     action :nothing
   end
  
-  bash "setup-spm" do
+  bash "setup-sematext" do
     user "root"
     cwd "/tmp"
-    code "bash /opt/spm/bin/setup-spm --app-token #{node.spm[:token]} --app-type elasticsearch --agent-type standalone"
+    code "bash /opt/spm/bin/setup-sematext --monitoring-token #{node.spm[:token]} --app-type elasticsearch --agent-type standalone"
     creates "/opt/spm/spm-monitor/conf/spm-monitor-config-#{node.spm[:token]}-default.properties"
     notifies :restart, "service[spm-monitor]"
   end

--- a/docs/monitoring/spm-faq.md
+++ b/docs/monitoring/spm-faq.md
@@ -130,12 +130,12 @@ step should be run once for each of the 3 Solr instances (installation
 instructions are accessible
 from <https://apps.sematext.com/ui/monitoring>, click Actions \> Install
 Monitor for app you are installing). When running
-script `/opt/spm/bin/setup-spm` in step "2. Client
+script `/opt/spm/bin/setup-sematext` in step "2. Client
 configuration setup", you should add `jvm-name` parameter (and value)
 at the end of parameter list, like this:
 
 ```
-sudo bash /opt/spm/bin/setup-spm --app-token 11111111-1111-1111-1111-111111111111 --app-type solr --agent-type javaagent --jvm-name solr1
+sudo bash /opt/spm/bin/setup-sematext --monitoring-token 11111111-1111-1111-1111-111111111111 --app-type solr --agent-type javaagent --jvm-name solr1
 ```
 
 In this example, we are setting up things for 3 separate Solr processes,


### PR DESCRIPTION
Rename of:
- app-token into monitoring-token
- setup-spm into setup-sematext

These are docs specific to "our" spm-client (not the public one) so changes should be good (they don't fully apply to public AA though).