### PR TITLE
Extract Solr monitoring to docs pages

### DIFF
--- a/docs/integration/solr.md
+++ b/docs/integration/solr.md
@@ -53,7 +53,7 @@ SOLR_OPTS="$SOLR_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxrem
 
 Make sure that tag ```<jmx />``` is enabled in your ```solrconfig.xml``` file.
 
-**You need to restart your SolrCloud node after the changes above.**
+**You need to restart your Solr node after the changes above.**
 
 ## Collected Metrics
 

--- a/docs/integration/solr.md
+++ b/docs/integration/solr.md
@@ -4,7 +4,7 @@ description:  Our monitoring and logging platform includes integration for Solr.
 Sematext offers simple and versatile Solr monitoring agent written in Java and Golang without CPU and memory overhead on your application. It's easy to install and require no changes in Solr source code or your application source code. 
 
 ## Sematext Solr Monitoring Agent 
-This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Kafka performance metrics and sends them to Sematext. It comes packages with a Golang-based agent responsible for Operating System level metrics like network, I/O and more. The Solr Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
+This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Kafka performance metrics and sends them to Sematext. It comes packaged with a Golang-based agent responsible for Operating System level metrics like network, I/O and more. The Solr Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
 
 The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it's running as a separate process and doesn't require a Solr restart when it is upgraded.
 

--- a/docs/integration/solr.md
+++ b/docs/integration/solr.md
@@ -4,7 +4,7 @@ description:  Our monitoring and logging platform includes integration for Solr.
 Sematext offers simple and versatile Solr monitoring agent written in Java and Golang with minimal CPU and memory overhead. It's easy to install and require no changes in Solr source code or your application source code. 
 
 ## Sematext Solr Monitoring Agent 
-This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Solr performance metrics and sends them to Sematext. It comes packaged with a Golang-based agent responsible for Operating System level metrics like network, disk I/O, and more. The Solr Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
+This lightweight, open-source [Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Solr performance metrics and sends them to Sematext. It comes packaged with a Golang-based agent responsible for Operating System level metrics like network, disk I/O, and more. The Solr Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
 
 The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it runs as a separate process and doesn't require a Solr restart when it is installed or upgraded.
 

--- a/docs/integration/solr.md
+++ b/docs/integration/solr.md
@@ -1,8 +1,114 @@
 title: Solr Monitoring Integration
 description:  Our monitoring and logging platform includes integration for Solr. Use predefined key metrics reports combined with rich data visualization tools to monitor critical Solr issues, and receive alerts on memory usage, uptime, load averages, index stats, document and filter caches, latency, rate, and more
 
+Sematext offers simple and versatile Solr monitoring agent written in Java and Golang without CPU and memory overhead on your application. It's easy to install and require no changes in Solr source code or your application source code. 
+
+## Sematext Solr Monitoring Agent 
+This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Solr performance metrics and sends them to Sematext. The second part of the Sematext Solr Monitoring Agent is a Golang based agent responsible for Operating System level metrics like network, I/O and more. 
+
+The Sematext Solr Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially setup, but will require restring your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of *standalone* agent mode is that it is running as a separate process and doesn't require Solr restart when it is upgraded.
+
+After creating a [Solr App in Sematext](https://apps.sematext.com/ui/monitoring-create) you need to install the Monitoring Agent on each host that is running Solr that you want to monitor. The full installation instructions can be found in the [setup instructions](https://apps.sematext.com/ui/howto/Solr/overview) displayed in the UI. 
+
+For example, on Ubuntu, you need to add Sematext Linux packages and install them with the following command:
+```bash
+echo "deb http://pub-repo.sematext.com/ubuntu sematext main" | sudo tee
+/etc/apt/sources.list.d/sematext.list > /dev/null
+wget -O - https://pub-repo.sematext.com/ubuntu/sematext.gpg.key | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install spm-client
+``` 
+
+After that you need to setup the Solr Monitoring Agent by preparing running a command like this:
+```bash
+sudo bash /opt/spm/bin/setup-sematext  \
+    --monitoring-token <your-monitoring-token-goes-here>   \
+    --app-type solr  \
+    --agent-type javaagent  \
+    --infra-token <your-infra-token-goes-here>
+```
+
+The above command will setup your Solr Monitoring Agent in the *in-process* mode, to have it running in the *standalone* mode instead of running the above command, run the one shown below:
+```bash
+sudo bash /opt/spm/bin/setup-sematext  \
+    --monitoring-token <your-monitoring-token-goes-here>   \
+    --app-type solr  \
+    --agent-type standalone  \
+    --infra-token <your-infra-token-goes-here>  \
+    --jmx-params '-Dspm.remote.jmx.url=localhost:3000'
+```
+
+Keep in mind that your need to provide the Monitoring token and Infra token. They are both provided in the [installation instructions](https://apps.sematext.com/ui/howto/Solr/overview) for your Solr App. 
+
+Finally, the last thing that needs to be done is adjusting the ```solr.in.sh``` file and add the following section:
+```bash
+SOLR_OPTS="$SOLR_OPTS -Dcom.sun.management.jmxremote
+-javaagent:/opt/spm/spm-monitor/lib/spm-monitor-generic.jar=<your-monitoring-token-goes-here>::default"
+```
+
+Or if you would like to run the Solr Monitoring Agent in the *standalone* mode add the following section to the ```solr.in.sh``` file:
+```bash
+SOLR_OPTS="$SOLR_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=3000 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+```
+
+Make sure that tag ```<jmx />``` is enabled in your ```solrconfig.xml``` file.
+
+**You need to restart your SolrCloud node after the above changes.**
+
+## Collected Metrics
+
+The Sematext Solr monitoring agent collects the following metrics.
+
+### Operating System
+
+- CPU usage
+- CPU load
+- Memory usage 
+- Swap usage
+- Disk space used
+- I/O Reads and Writes
+- Network traffic
+
+![](https://sematext.com/wp-content/uploads/2019/05/d_solr_cpu_details.png)
+
+### Java Virtual Machine
+
+- Grabage collectors time and count
+- JVM pool size and utilization
+- Threads and daemon threads
+- Files opened by the JVM
+
+![](https://sematext.com/wp-content/uploads/2019/05/d_solr_jvm_pool.png)
+
+### Solr
+
+- Requests rate and latency 
+- Solr index stats and file system stats
+- Added and pending documents
+- Deletes by id and queries
+- Filter cache statistics
+- Document cache statistics
+- Query result cache statistics
+- Per segment filter cache statistics
+- Commit events 
+- Warmup times
+
+![](https://sematext.com/wp-content/uploads/2019/05/d_solr_requests.png)
+
+## Troubleshooting
+
+If you are having issues with Sematext Monitoring, i.e. not seeing Solr metrics, you can create diagnostics package on affected machines where Solr Monitoring Agent installed by running:
+
+```bash
+sudo bash /opt/spm/bin/spm-client-diagnostics.sh
+```
+
+The resulting package will contain all relevant info needed for our investigation. You can send it, along with short description of your problem, to support@sematext.com or contact us in the chat.
+
 ## Integration
 
+- Agent: [https://github.com/sematext/sematext-agent-java](https://github.com/sematext/sematext-agent-java)
+- Tutorial: [https://sematext.com/blog/solr-monitoring-made-easy-with-sematext/](https://sematext.com/blog/solr-monitoring-made-easy-with-sematext/)
 - Instructions: [https://apps.sematext.com/ui/howto/Solr/overview](https://apps.sematext.com/ui/howto/Solr/overview)
 
 ## Metrics
@@ -45,14 +151,14 @@ autocommit max time<br>**solr.indexing.commits.auto.time.max** <br>*(long gauge)
 
 ** How do I enable JMX in Solr? **
 
-Add or uncomment the **<jmx/\>** directive in solrconfig.xml and
+Add or uncomment the **<jmx/\>** directive in ```solrconfig.xml``` and
 restart Solr.  See <https://wiki.apache.org/solr/SolrJmx> for more
 info.
 
 ** I don't see any data on Solr and JVM reports, what is the problem? **
 
 You should probably enable JMX in your Solr. Add or uncomment
-the **<jmx /\>** directive in **solrconfig.xml** and restart Solr.
+the **<jmx /\>** directive in ```solrconfig.xml``` and restart Solr.
  See <https://wiki.apache.org/solr/SolrJmx> for more info.
 
 ** I don't see any data only in Solr Components or Errors reports, what should I do? **

--- a/docs/integration/solr.md
+++ b/docs/integration/solr.md
@@ -4,7 +4,7 @@ description:  Our monitoring and logging platform includes integration for Solr.
 Sematext offers simple and versatile Solr monitoring agent written in Java and Golang without CPU and memory overhead on your application. It's easy to install and require no changes in Solr source code or your application source code. 
 
 ## Sematext Solr Monitoring Agent 
-This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Solr performance metrics and sends them to Sematext. The second part of the Sematext Solr Monitoring Agent is a Golang-based agent responsible for Operating System level metrics like network, I/O and more. 
+This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Kafka performance metrics and sends them to Sematext. It comes packages with a Golang-based agent responsible for Operating System level metrics like network, I/O and more. The Solr Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
 
 The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it's running as a separate process and doesn't require a Solr restart when it is upgraded.
 

--- a/docs/integration/solr.md
+++ b/docs/integration/solr.md
@@ -4,9 +4,9 @@ description:  Our monitoring and logging platform includes integration for Solr.
 Sematext offers simple and versatile Solr monitoring agent written in Java and Golang without CPU and memory overhead on your application. It's easy to install and require no changes in Solr source code or your application source code. 
 
 ## Sematext Solr Monitoring Agent 
-This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Solr performance metrics and sends them to Sematext. The second part of the Sematext Solr Monitoring Agent is a Golang based agent responsible for Operating System level metrics like network, I/O and more. 
+This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Solr performance metrics and sends them to Sematext. The second part of the Sematext Solr Monitoring Agent is a Golang-based agent responsible for Operating System level metrics like network, I/O and more. 
 
-The Sematext Solr Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially setup, but will require restring your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of *standalone* agent mode is that it is running as a separate process and doesn't require Solr restart when it is upgraded.
+The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it's running as a separate process and doesn't require a Solr restart when it is upgraded.
 
 After creating a [Solr App in Sematext](https://apps.sematext.com/ui/monitoring-create) you need to install the Monitoring Agent on each host that is running Solr that you want to monitor. The full installation instructions can be found in the [setup instructions](https://apps.sematext.com/ui/howto/Solr/overview) displayed in the UI. 
 
@@ -28,7 +28,7 @@ sudo bash /opt/spm/bin/setup-sematext  \
     --infra-token <your-infra-token-goes-here>
 ```
 
-The above command will setup your Solr Monitoring Agent in the *in-process* mode, to have it running in the *standalone* mode instead of running the above command, run the one shown below:
+The command above will set up your Solr Monitoring Agent in the *in-process* mode. To have it running in the *standalone* mode, run the command below instead of the one above:
 ```bash
 sudo bash /opt/spm/bin/setup-sematext  \
     --monitoring-token <your-monitoring-token-goes-here>   \
@@ -53,7 +53,7 @@ SOLR_OPTS="$SOLR_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxrem
 
 Make sure that tag ```<jmx />``` is enabled in your ```solrconfig.xml``` file.
 
-**You need to restart your SolrCloud node after the above changes.**
+**You need to restart your SolrCloud node after the changes above.**
 
 ## Collected Metrics
 
@@ -97,13 +97,13 @@ The Sematext Solr monitoring agent collects the following metrics.
 
 ## Troubleshooting
 
-If you are having issues with Sematext Monitoring, i.e. not seeing Solr metrics, you can create diagnostics package on affected machines where Solr Monitoring Agent installed by running:
+If you are having issues with Sematext Monitoring, i.e. not seeing Solr metrics, you can create a diagnostics package on any affected machines where SolrCloud Monitoring Agent installed by running:
 
 ```bash
 sudo bash /opt/spm/bin/spm-client-diagnostics.sh
 ```
 
-The resulting package will contain all relevant info needed for our investigation. You can send it, along with short description of your problem, to support@sematext.com or contact us in the chat.
+The resulting package will contain all relevant info needed for our investigation. You can send it, along with a short description of your problem, to support@sematext.com or contact us through the chat in the bottom right.
 
 ## Integration
 

--- a/docs/integration/solr.md
+++ b/docs/integration/solr.md
@@ -19,7 +19,7 @@ sudo apt-get update
 sudo apt-get install spm-client
 ``` 
 
-After that you need to setup the Solr Monitoring Agent by preparing running a command like this:
+After that you need to setup the Solr Monitoring Agent by running a command like this:
 ```bash
 sudo bash /opt/spm/bin/setup-sematext  \
     --monitoring-token <your-monitoring-token-goes-here>   \

--- a/docs/integration/solr.md
+++ b/docs/integration/solr.md
@@ -1,14 +1,14 @@
 title: Solr Monitoring Integration
 description:  Our monitoring and logging platform includes integration for Solr. Use predefined key metrics reports combined with rich data visualization tools to monitor critical Solr issues, and receive alerts on memory usage, uptime, load averages, index stats, document and filter caches, latency, rate, and more
 
-Sematext offers simple and versatile Solr monitoring agent written in Java and Golang without CPU and memory overhead on your application. It's easy to install and require no changes in Solr source code or your application source code. 
+Sematext offers simple and versatile Solr monitoring agent written in Java and Golang with minimal CPU and memory overhead. It's easy to install and require no changes in Solr source code or your application source code. 
 
 ## Sematext Solr Monitoring Agent 
-This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Kafka performance metrics and sends them to Sematext. It comes packaged with a Golang-based agent responsible for Operating System level metrics like network, I/O and more. The Solr Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
+This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Solr performance metrics and sends them to Sematext. It comes packaged with a Golang-based agent responsible for Operating System level metrics like network, disk I/O, and more. The Solr Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
 
-The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it's running as a separate process and doesn't require a Solr restart when it is upgraded.
+The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it runs as a separate process and doesn't require a Solr restart when it is installed or upgraded.
 
-After creating a [Solr App in Sematext](https://apps.sematext.com/ui/monitoring-create) you need to install the Monitoring Agent on each host that is running Solr that you want to monitor. The full installation instructions can be found in the [setup instructions](https://apps.sematext.com/ui/howto/Solr/overview) displayed in the UI. 
+After creating a [Solr App in Sematext](https://apps.sematext.com/ui/monitoring-create) you need to install the Monitoring Agent on each host running Solr that you want to monitor. The full installation instructions can be found in the [setup instructions](https://apps.sematext.com/ui/howto/Solr/overview) displayed in the UI. 
 
 For example, on Ubuntu, you need to add Sematext Linux packages and install them with the following command:
 ```bash
@@ -19,7 +19,7 @@ sudo apt-get update
 sudo apt-get install spm-client
 ``` 
 
-After that you need to setup the Solr Monitoring Agent by running a command like this:
+After that, setup the Solr Monitoring Agent by running a command like this:
 ```bash
 sudo bash /opt/spm/bin/setup-sematext  \
     --monitoring-token <your-monitoring-token-goes-here>   \
@@ -73,7 +73,7 @@ The Sematext Solr monitoring agent collects the following metrics.
 
 ### Java Virtual Machine
 
-- Grabage collectors time and count
+- Garbage collectors time and count
 - JVM pool size and utilization
 - Threads and daemon threads
 - Files opened by the JVM
@@ -97,13 +97,15 @@ The Sematext Solr monitoring agent collects the following metrics.
 
 ## Troubleshooting
 
-If you are having issues with Sematext Monitoring, i.e. not seeing Solr metrics, you can create a diagnostics package on any affected machines where SolrCloud Monitoring Agent installed by running:
+If you are having issues with Sematext Monitoring, i.e. not seeing SolrCloud metrics, you can create a diagnostics package on any affected machines where SolrCloud Monitoring Agent installed by running:
 
 ```bash
 sudo bash /opt/spm/bin/spm-client-diagnostics.sh
 ```
 
 The resulting package will contain all relevant info needed for our investigation. You can send it, along with a short description of your problem, to support@sematext.com or contact us through the chat in the bottom right.
+
+For more troubleshooting information please look at [Troubleshooting](/monitoring/spm-faq/#troubleshooting) section.
 
 ## Integration
 

--- a/docs/integration/solrcloud.md
+++ b/docs/integration/solrcloud.md
@@ -4,7 +4,7 @@ description:  Our monitoring and logging platform includes integration for SolrC
 Sematext offers simple and versatile SolrCloud monitoring agent written in Java and Golang with minimal CPU and memory overhead. It's easy to install and require no changes in the SolrCloud source code or your application's source code. 
 
 ## Sematext SolrCloud Monitoring Agent 
-This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects SolrCloud performance metrics and sends them to Sematext. It comes packaged with a Golang-based agent responsible for Operating System level metrics like network, disk I/O, and more. The SolrCloud Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
+This lightweight, open-source [Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects SolrCloud performance metrics and sends them to Sematext. It comes packaged with a Golang-based agent responsible for Operating System level metrics like network, disk I/O, and more. The SolrCloud Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
 
 The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it runs as a separate process and doesn't require a Solr restart when it is installed or upgraded.
 

--- a/docs/integration/solrcloud.md
+++ b/docs/integration/solrcloud.md
@@ -1,9 +1,112 @@
 title: SolrCloud Monitoring Integration
 description:  Our monitoring and logging platform includes integration for SolrCloud. Use predefined key metrics reports combined with rich data visualization tools to monitor critical issues on your Solr machines cluster, and receive alerts on memory usage, uptime, load averages, index stats, document and filter caches, latency, rate, and more
 
+Sematext offers simple and versatile SolrCloud monitoring agent written in Java and Golang without CPU and memory overhead on your application. It's easy to install and require no changes in SolrCloud source code or your application source code. 
+
+## Sematext SolrCloud Monitoring Agent 
+This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects SolrCloud performance metrics and sends them to Sematext. The second part of the Sematext SolrCloud Monitoring Agent is a Golang based agent responsible for Operating System level metrics like network, I/O and more. 
+
+The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially setup, but will require restring your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of *standalone* agent mode is that it is running as a separate process and doesn't require Solr restart when it is upgraded.
+
+After creating a [SolrCloud App in Sematext](https://apps.sematext.com/ui/monitoring-create) you need to install the Monitoring Agent on each host that is running your SolrCloud nodes to have the full visibility over the metrics from each host. The full installation instructions can be found in the [setup instructions](https://apps.sematext.com/ui/howto/SolrCloud/overview) displayed in the UI. 
+
+For example, on CentOS, you need to add Sematext Linux packages and install them with the following command:
+```bash
+sudo wget https://pub-repo.sematext.com/centos/sematext.repo -O /etc/yum.repos.d/sematext.repo
+sudo yum clean all
+sudo yum install spm-client
+``` 
+
+After that you need to setup the SolrCloud Monitoring Agent by preparing running a command like this:
+```bash
+sudo bash /opt/spm/bin/setup-sematext  \
+    --monitoring-token <your-monitoring-token-goes-here>   \
+    --app-type solrcloud  \
+    --agent-type javaagent  \
+    --infra-token <your-infra-token-goes-here>
+```
+
+The above command will setup your SolrCloud Monitoring Agent in the *in-process* mode, to have it running in the *standalone* mode instead of running the above command, run the one shown below:
+```bash
+sudo bash /opt/spm/bin/setup-sematext  \
+    --monitoring-token <your-monitoring-token-goes-here>   \
+    --app-type solr  \
+    --agent-type standalone  \
+    --infra-token <your-infra-token-goes-here>  \
+    --jmx-params '-Dspm.remote.jmx.url=localhost:3000'
+```
+
+Keep in mind that your need to provide the Monitoring token and Infra token. They are both provided in the [installation instructions](https://apps.sematext.com/ui/howto/SolrCloud/overview) for your SolrCloud App. 
+
+Finally, the last thing that needs to be done is adjusting the *solr.in.sh* file and add the following section:
+```bash
+SOLR_OPTS="$SOLR_OPTS -Dcom.sun.management.jmxremote -javaagent:/opt/spm/spm-monitor/lib/spm-monitor-generic.jar=<your-monitoring-token-goes-here>::default"
+```
+
+Or if you would like to run the Solr Monitoring Agent in the *standalone* mode add the following section to the ```solr.in.sh``` file:
+```bash
+SOLR_OPTS="$SOLR_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=3000 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+```
+
+Make sure that tag ```<jmx />``` is enabled in your ```solrconfig.xml``` file.
+
+**You need to restart your SolrCloud node after the above changes.**
+
+## Collected Metrics
+
+The Sematext SolrCloud monitoring agent collects the following metrics.
+
+### Operating System
+
+- CPU usage
+- CPU load
+- Memory usage 
+- Swap usage
+- Disk space used
+- I/O Reads and Writes
+- Network traffic
+
+![](https://sematext.com/wp-content/uploads/2019/05/d_solr_cpu_details.png)
+
+### Java Virtual Machine
+
+- Grabage collectors time and count
+- JVM pool size and utilization
+- Threads and daemon threads
+- Files opened by the JVM
+
+![](https://sematext.com/wp-content/uploads/2019/05/d_solr_jvm_pool.png)
+
+### Solr
+
+- Requests rate and latency 
+- Solr index stats and file system stats
+- Added and pending documents
+- Deletes by id and queries
+- Filter cache statistics
+- Document cache statistics
+- Query result cache statistics
+- Per segment filter cache statistics
+- Commit events 
+- Warmup times
+
+![](https://sematext.com/wp-content/uploads/2019/05/d_solr_requests.png)
+
+## Troubleshooting
+
+If you are having issues with Sematext Monitoring, i.e. not seeing SolrCloud metrics, you can create diagnostics package on affected machines where SolrCloud Monitoring Agent installed by running:
+
+```bash
+sudo bash /opt/spm/bin/spm-client-diagnostics.sh
+```
+
+The resulting package will contain all relevant info needed for our investigation. You can send it, along with short description of your problem, to support@sematext.com or contact us in the chat.
+
 ## Integration
 
-- Instructions: [https://apps.sematext.com/ui/howto/SolrCloud/overview](https://apps.sematext.com/ui/howto/SolrCloud/overview)
+- Agent: [https://github.com/sematext/sematext-agent-java](https://github.com/sematext/sematext-agent-java)
+- Tutorial: [https://sematext.com/blog/solr-monitoring-made-easy-with-sematext/](https://sematext.com/blog/solr-monitoring-made-easy-with-sematext/)
+- Instructions: [https://apps.sematext.com/ui/howto/Solr/overview](https://apps.sematext.com/ui/howto/Solr/overview)
 
 ## Metrics
 

--- a/docs/integration/solrcloud.md
+++ b/docs/integration/solrcloud.md
@@ -4,7 +4,7 @@ description:  Our monitoring and logging platform includes integration for SolrC
 Sematext offers simple and versatile SolrCloud monitoring agent written in Java and Golang without CPU and memory overhead. It's easy to install and requires no changes in the SolrCloud source code or your application's source code. 
 
 ## Sematext SolrCloud Monitoring Agent 
-This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Kafka performance metrics and sends them to Sematext. It comes packages with a Golang-based agent responsible for Operating System level metrics like network, I/O and more. The SolrCloud Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
+This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Kafka performance metrics and sends them to Sematext. It comes packaged with a Golang-based agent responsible for Operating System level metrics like network, I/O and more. The SolrCloud Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
 
 The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it's running as a separate process and doesn't require a Solr restart when it is upgraded.
 

--- a/docs/integration/solrcloud.md
+++ b/docs/integration/solrcloud.md
@@ -1,12 +1,12 @@
 title: SolrCloud Monitoring Integration
 description:  Our monitoring and logging platform includes integration for SolrCloud. Use predefined key metrics reports combined with rich data visualization tools to monitor critical issues on your Solr machines cluster, and receive alerts on memory usage, uptime, load averages, index stats, document and filter caches, latency, rate, and more
 
-Sematext offers simple and versatile SolrCloud monitoring agent written in Java and Golang without CPU and memory overhead on your application. It's easy to install and require no changes in SolrCloud source code or your application source code. 
+Sematext offers simple and versatile SolrCloud monitoring agent written in Java and Golang without CPU and memory overhead. It's easy to install and requires no changes in the SolrCloud source code or your application's source code. 
 
 ## Sematext SolrCloud Monitoring Agent 
-This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects SolrCloud performance metrics and sends them to Sematext. The second part of the Sematext SolrCloud Monitoring Agent is a Golang based agent responsible for Operating System level metrics like network, I/O and more. 
+This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects SolrCloud performance metrics and sends them to Sematext. The second part of the Sematext SolrCloud Monitoring Agent is a Golang-based agent responsible for Operating System level metrics like network, I/O and more. 
 
-The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially setup, but will require restring your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of *standalone* agent mode is that it is running as a separate process and doesn't require Solr restart when it is upgraded.
+The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it's running as a separate process and doesn't require a Solr restart when it is upgraded.
 
 After creating a [SolrCloud App in Sematext](https://apps.sematext.com/ui/monitoring-create) you need to install the Monitoring Agent on each host that is running your SolrCloud nodes to have the full visibility over the metrics from each host. The full installation instructions can be found in the [setup instructions](https://apps.sematext.com/ui/howto/SolrCloud/overview) displayed in the UI. 
 
@@ -26,7 +26,7 @@ sudo bash /opt/spm/bin/setup-sematext  \
     --infra-token <your-infra-token-goes-here>
 ```
 
-The above command will setup your SolrCloud Monitoring Agent in the *in-process* mode, to have it running in the *standalone* mode instead of running the above command, run the one shown below:
+The command above will set up your SolrCloud Monitoring Agent in the *in-process* mode. To have it running in the *standalone* mode, run the command below instead of the one above:
 ```bash
 sudo bash /opt/spm/bin/setup-sematext  \
     --monitoring-token <your-monitoring-token-goes-here>   \
@@ -50,7 +50,7 @@ SOLR_OPTS="$SOLR_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxrem
 
 Make sure that tag ```<jmx />``` is enabled in your ```solrconfig.xml``` file.
 
-**You need to restart your SolrCloud node after the above changes.**
+**You need to restart your SolrCloud node after the changes above.**
 
 ## Collected Metrics
 
@@ -94,13 +94,13 @@ The Sematext SolrCloud monitoring agent collects the following metrics.
 
 ## Troubleshooting
 
-If you are having issues with Sematext Monitoring, i.e. not seeing SolrCloud metrics, you can create diagnostics package on affected machines where SolrCloud Monitoring Agent installed by running:
+If you are having issues with Sematext Monitoring, i.e. not seeing SolrCloud metrics, you can create a diagnostics package on any affected machines where SolrCloud Monitoring Agent installed by running:
 
 ```bash
 sudo bash /opt/spm/bin/spm-client-diagnostics.sh
 ```
 
-The resulting package will contain all relevant info needed for our investigation. You can send it, along with short description of your problem, to support@sematext.com or contact us in the chat.
+The resulting package will contain all relevant info needed for our investigation. You can send it, along with a short description of your problem, to support@sematext.com or contact us through the chat in the bottom right.
 
 ## Integration
 

--- a/docs/integration/solrcloud.md
+++ b/docs/integration/solrcloud.md
@@ -1,14 +1,14 @@
 title: SolrCloud Monitoring Integration
 description:  Our monitoring and logging platform includes integration for SolrCloud. Use predefined key metrics reports combined with rich data visualization tools to monitor critical issues on your Solr machines cluster, and receive alerts on memory usage, uptime, load averages, index stats, document and filter caches, latency, rate, and more
 
-Sematext offers simple and versatile SolrCloud monitoring agent written in Java and Golang without CPU and memory overhead. It's easy to install and requires no changes in the SolrCloud source code or your application's source code. 
+Sematext offers simple and versatile SolrCloud monitoring agent written in Java and Golang with minimal CPU and memory overhead. It's easy to install and require no changes in the SolrCloud source code or your application's source code. 
 
 ## Sematext SolrCloud Monitoring Agent 
-This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Kafka performance metrics and sends them to Sematext. It comes packaged with a Golang-based agent responsible for Operating System level metrics like network, I/O and more. The SolrCloud Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
+This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects SolrCloud performance metrics and sends them to Sematext. It comes packaged with a Golang-based agent responsible for Operating System level metrics like network, disk I/O, and more. The SolrCloud Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
 
-The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it's running as a separate process and doesn't require a Solr restart when it is upgraded.
+The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it runs as a separate process and doesn't require a Solr restart when it is installed or upgraded.
 
-After creating a [SolrCloud App in Sematext](https://apps.sematext.com/ui/monitoring-create) you need to install the Monitoring Agent on each host that is running your SolrCloud nodes to have the full visibility over the metrics from each host. The full installation instructions can be found in the [setup instructions](https://apps.sematext.com/ui/howto/SolrCloud/overview) displayed in the UI. 
+After creating a [SolrCloud App in Sematext](https://apps.sematext.com/ui/monitoring-create) you need to install the Monitoring Agent on each host running your SolrCloud nodes to have the full visibility over the metrics from each host. The full installation instructions can be found in the [setup instructions](https://apps.sematext.com/ui/howto/SolrCloud/overview) displayed in the UI. 
 
 For example, on CentOS, you need to add Sematext Linux packages and install them with the following command:
 ```bash
@@ -17,7 +17,7 @@ sudo yum clean all
 sudo yum install spm-client
 ``` 
 
-After that you need to setup the SolrCloud Monitoring Agent by running a command like this:
+After that, setup the SolrCloud Monitoring Agent by running a command like this:
 ```bash
 sudo bash /opt/spm/bin/setup-sematext  \
     --monitoring-token <your-monitoring-token-goes-here>   \
@@ -70,7 +70,7 @@ The Sematext SolrCloud monitoring agent collects the following metrics.
 
 ### Java Virtual Machine
 
-- Grabage collectors time and count
+- Garbage collectors time and count
 - JVM pool size and utilization
 - Threads and daemon threads
 - Files opened by the JVM
@@ -101,6 +101,8 @@ sudo bash /opt/spm/bin/spm-client-diagnostics.sh
 ```
 
 The resulting package will contain all relevant info needed for our investigation. You can send it, along with a short description of your problem, to support@sematext.com or contact us through the chat in the bottom right.
+
+For more troubleshooting information please look at [Troubleshooting](/monitoring/spm-faq/#troubleshooting) section.
 
 ## Integration
 

--- a/docs/integration/solrcloud.md
+++ b/docs/integration/solrcloud.md
@@ -17,7 +17,7 @@ sudo yum clean all
 sudo yum install spm-client
 ``` 
 
-After that you need to setup the SolrCloud Monitoring Agent by preparing running a command like this:
+After that you need to setup the SolrCloud Monitoring Agent by running a command like this:
 ```bash
 sudo bash /opt/spm/bin/setup-sematext  \
     --monitoring-token <your-monitoring-token-goes-here>   \

--- a/docs/integration/solrcloud.md
+++ b/docs/integration/solrcloud.md
@@ -4,7 +4,7 @@ description:  Our monitoring and logging platform includes integration for SolrC
 Sematext offers simple and versatile SolrCloud monitoring agent written in Java and Golang without CPU and memory overhead. It's easy to install and requires no changes in the SolrCloud source code or your application's source code. 
 
 ## Sematext SolrCloud Monitoring Agent 
-This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects SolrCloud performance metrics and sends them to Sematext. The second part of the Sematext SolrCloud Monitoring Agent is a Golang-based agent responsible for Operating System level metrics like network, I/O and more. 
+This lightweight, open-source [Java Monitoring Agent](https://github.com/sematext/sematext-agent-java) collects Kafka performance metrics and sends them to Sematext. It comes packages with a Golang-based agent responsible for Operating System level metrics like network, I/O and more. The SolrCloud Monitoring Agent can be installed with RPM/DEB package manager on any host running Linux or in a containerized environment using ```sematext/spm-client```.
 
 The Sematext SolrCloud Monitoring Agent can be run in two different modes - *in-process* and *standalone*. The *in-process* one is run as a Java agent, it is simpler to initially set up, but will require restarting your Solr node when you will want to upgrade your monitoring Agent, i.e. to get new features. The benefit of the *standalone* agent mode is that it's running as a separate process and doesn't require a Solr restart when it is upgraded.
 


### PR DESCRIPTION
I adjusted the Solr and SolrCloud monitoring pages in the docs to include material from our Monitoring Solr with Sematext blog post. 