### PR TITLE
Unify dupes for process and container monitoring pages and relevant STA pages

### DIFF
--- a/docs/agents/sematext-agent/containers/configuration.md
+++ b/docs/agents/sematext-agent/containers/configuration.md
@@ -1,4 +1,5 @@
-## Configuration file
+title: Configuration file
+description: For fine-tuning Sematext Agent refer to `st-agent.yml` configuration file.
 
 For fine-tuning Sematext Agent refer to `st-agent.yml` configuration file. You will have to mount the file from the host into the container file system and set `CONFIG_FILE` environment variable to specify the path to the aforementioned configuration file.
 

--- a/docs/agents/sematext-agent/containers/installation.md
+++ b/docs/agents/sematext-agent/containers/installation.md
@@ -1,3 +1,9 @@
+title: Installation
+description: To deploy the Sematext Agent as a container, run a simple command on each one of your hosts.
+
+Installing Sematext Agent can be done by using Docker, Docker Compose, and Docker Swarm / Enterprise.
+
+## Docker
 To deploy the Sematext Agent as a container, run the following command on each host:
 
 ```bash
@@ -26,7 +32,7 @@ By default, the US region receiver endpoints are used to ship data to Sematext C
 
 **Note that if any of the** `*_URL` **environment variables are set, region specific receiver endpoints are ignored.**
 
-#### Run Sematext Agent with a Config File
+### Run Sematext Agent with a Config File
 
 Mount the configuration file into the container and set the path to the configuration file ```-v /opt/st-agent/st-agent.yml:/opt/st-agent/st-agent.yml ``` via `CONFIG_FILE` environment variable.
 
@@ -79,7 +85,7 @@ services:
       - '/usr/lib:/host/usr/lib:ro'
 ```
 
-## Docker Enterprise / Swarm
+## Docker Swarm / Enterprise
 
 Create a Docker Monitoring App in Sematext and follow the instructions in the UI.
 Sematext Agent can be deployed as global service on all Swarm nodes with a single command:

--- a/docs/agents/sematext-agent/index.md
+++ b/docs/agents/sematext-agent/index.md
@@ -1,4 +1,5 @@
-## Sematext Agent
+title: Sematext Agent
+description: Sematext Agent collects a plethora of metrics about hosts (CPU, memory, disk, network, processes), containers (Docker, rkt, containerd) and orchestrator platforms.
 
 Sematext Agent collects a plethora of metrics about hosts (CPU, memory, disk, network, processes), containers (Docker, rkt, containerd) and orchestrator platforms and ships that to [Sematext Cloud](https://sematext.com/cloud). To gain deep insight into the Linux kernel, Sematext Agent relies on eBPF to implant instrumentation points (attach eBPF programs to kprobes) on kernel functions. Using Linux kernel instrumentation allows Sematext Agent a very efficient and powerful system exploration approach. It has the ability to auto-discover services deployed on physical/virtual hosts and containers, as well as a mechanism for reporting inventory info. It also collects events from different sources such as OOM notifications, system-wide kill events, container or Kubernetes events.
 

--- a/docs/agents/sematext-agent/processes/configuration.md
+++ b/docs/agents/sematext-agent/processes/configuration.md
@@ -1,4 +1,4 @@
-title: Enabling/Disabling Process Monitoring
+title: Configuring Process Monitoring
 description: Process Monitoring is enabled by default in the [Sematext Agent configuration.
 
 Process Monitoring is enabled by default in the [Sematext Agent configuration](../agents/sematext-agent/containers/configuration/). You can *disable* process metrics/metadata collection by setting the following properties:

--- a/docs/agents/sematext-agent/processes/enable-process-monitoring.md
+++ b/docs/agents/sematext-agent/processes/enable-process-monitoring.md
@@ -1,0 +1,32 @@
+title: Enabling/Disabling Process Monitoring
+description: Process Monitoring is enabled by default in the [Sematext Agent configuration.
+
+Process Monitoring is enabled by default in the [Sematext Agent configuration](../agents/sematext-agent/containers/configuration/). You can *disable* process metrics/metadata collection by setting the following properties:
+
+<div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
+ <div class="mdl-tabs__tab-bar">
+     <a href="#file-enabled" class="mdl-tabs__tab is-active">Config file</a>
+     <a href="#env-enabled" class="mdl-tabs__tab">Env variable</a>
+ </div>
+
+ <div class="mdl-tabs__panel is-active" id="file-enabled">
+   <pre>
+   # st-agent.yml
+   process:
+     enabled: false
+   </pre>
+ </div>
+ <div class="mdl-tabs__panel" id="env-enabled">
+   <pre>
+   PROCESS_ENABLED=false
+   </pre>
+ </div>
+</div>
+
+After that the [Sematext Agent](../agents/sematext-agent) needs to be restarted by running the following command:
+
+```
+sudo service/systemctl spm-monitor-st-agent restart
+```
+
+There are numerous settings you can configure for Process Monitoring in the Sematext Agent. Check out the [Metrics](./metrics) first!

--- a/docs/agents/sematext-agent/processes/metrics.md
+++ b/docs/agents/sematext-agent/processes/metrics.md
@@ -3,29 +3,7 @@ description: Process Monitoring memory CPU usage
 
 Sematext Agent gathers various metrics and metadata about running processes and brings them to [Sematext Cloud](https://sematext.com/cloud/) so you can painlessly explore the system resources allocated by processes whether they're executing on bare metal machines, VMs, plain containers or scheduled to run on multi-cluster Kubernetes workloads.
 
-Process collector is enabled by default. You can disable process metrics/metadata collection by setting the following properties:
-
-<div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
- <div class="mdl-tabs__tab-bar">
-     <a href="#file-enabled" class="mdl-tabs__tab is-active">Config file</a>
-     <a href="#env-enabled" class="mdl-tabs__tab">Env variable</a>
- </div>
-
- <div class="mdl-tabs__panel is-active" id="file-enabled">
-   <pre>
-   # st-agent.yml
-   process:
-     enabled: false
-   </pre>
- </div>
- <div class="mdl-tabs__panel" id="env-enabled">
-   <pre>
-   PROCESS_ENABLED=false
-   </pre>
- </div>
-</div>
-
-Similarly, to tweak the frequency of the process' data series collection and delivery to Sematext Cloud adjust the following options:
+To tweak the frequency of the process' data series collection and delivery to Sematext Cloud adjust the following options:
 
 <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
  <div class="mdl-tabs__tab-bar">
@@ -47,7 +25,7 @@ Similarly, to tweak the frequency of the process' data series collection and del
  </div>
 </div>
 
-### Metrics
+## Metrics
 
 The agent collects top _N_ processes by CPU and memory utilization. Once process is elected as a top resource consumer, it stays in the top N list for the time slice that has been allocated to it. It is relinquished from the top N list when there is another process with higher resource usage that displaces the current process or it leaves the top N list voluntarily (e.g. no longer detected as a relevant resource consumer).
 

--- a/docs/monitoring/containers.md
+++ b/docs/monitoring/containers.md
@@ -13,80 +13,9 @@ Creating a Sematext Monitoring App is as easy as choosing the Docker integration
 ## Install the Sematext Agent
 Sematext can easily monitor your containers with the Sematext Agent. [Installing](../agents/sematext-agent/containers/installation) the Agent is as simple as running one command on each host.
 
-For Docker:
-
-```bash
-docker run -d  --restart always --privileged -P --name st-agent \
--v /sys/kernel/debug:/sys/kernel/debug \
--v /var/run/:/var/run/ \
--v /proc:/host/proc:ro \
--v /etc:/host/etc:ro \
--v /sys:/host/sys:ro \
--v /usr/lib:/host/usr/lib:ro \
--e CONTAINER_TOKEN=<YOUR_DOCKER_APP_TOKEN_HERE> \
--e INFRA_TOKEN=<YOUR_INFRA_APP_TOKEN_HERE> \
--e REGION=<US or EU> \
--e JOURNAL_DIR=/var/run/st-agent \
--e LOGGING_WRITE_EVENTS=false \
--e LOGGING_REQUEST_TRACKING=false \
--e LOGGING_LEVEL=info \
--e NODE_NAME=`hostname` \
--e CONTAINER_SKIP_BY_IMAGE=sematext \
-sematext/agent:latest
-```
-
-For Docker Compose:
-
-```yaml
-# docker-compose.yml
-version: '3'
-services:
-  sematext-agent:
-    image: 'sematext/agent:latest'
-    environment:
-      - affinity:container!=*sematext-agent*
-      - CONTAINER_TOKEN=<YOUR_DOCKER_APP_TOKEN_HERE>
-      - INFRA_TOKEN=<YOUR_INFRA_APP_TOKEN_HERE>
-      - REGION=<US or EU>
-      - JOURNAL_DIR=/var/run/st-agent
-      - LOGGING_WRITE_EVENTS=false
-      - LOGGING_REQUEST_TRACKING=false
-      - LOGGING_LEVEL=info
-      - NODE_NAME=$HOSTNAME
-      - CONTAINER_SKIP_BY_IMAGE=sematext
-    cap_add:
-      - SYS_ADMIN
-    restart: always
-    volumes:
-      - '/var/run/:/var/run/'
-      - '/sys/kernel/debug:/sys/kernel/debug'
-      - '/proc:/host/proc:ro'
-      - '/etc:/host/etc:ro'
-      - '/sys:/host/sys:ro'
-      - '/usr/lib:/host/usr/lib:ro'
-```
-
-For Docker Swarm:
-
-```bash
-docker service create --mode global --name st-agent \
---restart-condition any \
---mount type=bind,src=/var/run,dst=/var/run/ \
---mount type=bind,src=/usr/lib,dst=/host/usr/lib \
---mount type=bind,src=/sys/kernel/debug,dst=/sys/kernel/debug \
---mount type=bind,src=/proc,dst=/host/proc,readonly \
---mount type=bind,src=/etc,dst=/host/etc,readonly \
---mount type=bind,src=/sys,dst=/host/sys,readonly \
--e NODE_NAME={{.Node.Hostname}} \
--e INFRA_TOKEN=<YOUR_INFRA_APP_TOKEN_HERE> \
--e CONTAINER_TOKEN=<YOUR_DOCKER_APP_TOKEN_HERE> \
--e REGION=<US or EU> \
--e JOURNAL_DIR=/var/run/st-agent \
--e LOGGING_REQUEST_TRACKING=false \
--e LOGGING_WRITE_EVENTS=false \
--e LOGGING_LEVEL=info \
-sematext/agent:latest
-```
+- [Docker](../../agents/sematext-agent/containers/installation/#docker)
+- [Docker Compose](../../agents/sematext-agent/containers/installation/docker-compose)
+- [Docker Swarm](../../agents/sematext-agent/containers/installation/#docker-swarm-enterprise)
 
 ## See Container data in Sematext Monitoring
 Sematext Agent collects a plethora of metrics about hosts (CPU, memory, disk, network, processes), containers (Docker, rkt, containerd) and orchestrator platforms and ships that to Sematext Cloud.

--- a/docs/monitoring/processes.md
+++ b/docs/monitoring/processes.md
@@ -8,7 +8,7 @@ Process Monitoring is available in the *Infrastructure Monitoring* section of yo
 ## Enabling Process Monitoring
 
 Process Monitoring is enabled by default in the [Sematext Agent configuration](../agents/sematext-agent/containers/configuration/). 
-Check out enabling and disabling Process Monitoring [here](../agents/sematext-agent/processes/enable-process-monitoring/). 
+Check out enabling and disabling Process Monitoring [here](../agents/sematext-agent/processes/configuration/). 
 
 ## Processes View
 
@@ -74,4 +74,4 @@ Here are some of the common use cases and issues that Process Monitoring helps t
 - Identify processes, containers or service with high resource usage
 
 ## More Details
-To read about the inner workings of Process Monitoring check out the [Processes section in the Sematext Agent docs](../agents/sematext-agent/processes/enable-process-monitoring/)!
+To read about the inner workings of Process Monitoring check out the [Processes section in the Sematext Agent docs](../agents/sematext-agent/processes/configuration/)!

--- a/docs/monitoring/processes.md
+++ b/docs/monitoring/processes.md
@@ -5,7 +5,12 @@ Process Monitoring gives you visibility into processes that use the most CPU or 
 
 Process Monitoring is available in the *Infrastructure Monitoring* section of your Sematext Cloud account - your central place for hosts, virtual machines, containers, and process information.
 
-### Processes View
+## Enabling Process Monitoring
+
+Process Monitoring is enabled by default in the [Sematext Agent configuration](../agents/sematext-agent/containers/configuration/). 
+Check out enabling and disabling Process Monitoring [here](../agents/sematext-agent/processes/enable-process-monitoring/). 
+
+## Processes View
 
 The processes view provides similar information as the Linux top command. It shows: 
 
@@ -41,28 +46,11 @@ Also, a real-time view of all process metrics is available in the metrics tab. T
 - IO read/write bytes 
 - IO read/write operations 
 
-## How does it Work?
+## How Does It Work?
 
 The [Sematext Agent](../agents/sematext-agent) tracks all processes and ships the metrics of the top N processes. The agent tags all metrics with process and container metadata and ships the metrics to your [Infra App](../infrastructure/).  
 
 Sematext UI provides visualizations, grouping and filter functionality. 
-
-
-## Enabling Process Monitoring
-
-Process Monitoring is enabled by default in the [Sematext Agent configuration](../agents/sematext-agent/containers/configuration/). 
-In case you want to *disable* Process Monitoring set the following option in the config file: 
-
-```
-process:
- enabled: false
-```
-
-After that the [Sematext Agent](../agents/sematext-agent) needs to be restarted by running the following command:
-
-```
-service spm-monitor-st-agent restart
-```
 
 ## Gathered Data
 
@@ -85,3 +73,5 @@ Here are some of the common use cases and issues that Process Monitoring helps t
 - Replace time-consuming operations to check system resources with `ssh` and `top` Linux commands
 - Identify processes, containers or service with high resource usage
 
+## More Details
+To read about the inner workings of Process Monitoring check out the [Processes section in the Sematext Agent docs](../agents/sematext-agent/processes/enable-process-monitoring/)!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ pages:
           - Configuration: agents/sematext-agent/kubernetes/configuration.md
           - Metrics: agents/sematext-agent/kubernetes/metrics.md
         - Processes:
+          - Enable/Disable: agents/sematext-agent/processes/enable-process-monitoring.md
           - Metrics: agents/sematext-agent/processes/metrics.md
           - Metadata: agents/sematext-agent/processes/metadata.md
           - Sensitive Data: agents/sematext-agent/processes/sensitive-data.md 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,7 +137,7 @@ pages:
           - Configuration: agents/sematext-agent/kubernetes/configuration.md
           - Metrics: agents/sematext-agent/kubernetes/metrics.md
         - Processes:
-          - Enable/Disable: agents/sematext-agent/processes/enable-process-monitoring.md
+          - Configuration: agents/sematext-agent/processes/configuration.md
           - Metrics: agents/sematext-agent/processes/metrics.md
           - Metadata: agents/sematext-agent/processes/metadata.md
           - Sensitive Data: agents/sematext-agent/processes/sensitive-data.md 


### PR DESCRIPTION
I've removed redundant content from monitoring > processes and monitoring > containers instead adding links to more detailed pages under sematext agent > processes and sematext agent > containers. Screenshots below.

Monitoring > Containers
![monitoring > containers](https://user-images.githubusercontent.com/15029531/60521976-78877600-9ce8-11e9-9835-30d608146ff4.png)

Sematext Agent > Containers > Installation
![Sematext Agent > Containers > Installation](https://user-images.githubusercontent.com/15029531/60522014-8937ec00-9ce8-11e9-90b6-3565330a9a6c.png)

Monitoring > Processes
![Monitoring > Processes](https://user-images.githubusercontent.com/15029531/60522208-dddb6700-9ce8-11e9-8bd4-5e2d390ff587.png)

Sematext Agent > Processes > Enable/Disable
![Sematext Agent > Processes > Enable/Disable](https://user-images.githubusercontent.com/15029531/60522247-ecc21980-9ce8-11e9-98c9-1033dfcb0b2e.png)

Sematext Agent > Processes > Metrics
![Sematext Agent > Processes > Metrics](https://user-images.githubusercontent.com/15029531/60522257-f0ee3700-9ce8-11e9-8ea0-9529cff66f04.png)

