### PR TITLE
Add `Packages` section to Sematext Agent

### DIFF
--- a/docs/agents/sematext-agent/packages/configuration.md
+++ b/docs/agents/sematext-agent/packages/configuration.md
@@ -30,7 +30,7 @@ You can *disable* package collection by setting the following properties:
  </div>
 </div>
 
-Additionally, you can tweak the interval that determines how often packages are scanned. By default, the interval is every 10 minutes. The agent retrieves packages from the file system and any running containers, then compares the current state to decide which packages should be reported as installed or removed, and finally ships the events to Sematext Cloud.
+Additionally, you can tweak the interval that determines how often packages are scanned. By default, the interval is every 10 minutes. The agent retrieves packages from the file system and any running containers, then compares the current state to decide which packages should be reported as installed or removed, and finally ships the events to Sematext Cloud. Asides from that, the agent proactively reacts to the file system changes and bulks the packages in real time.
 
 <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
  <div class="mdl-tabs__tab-bar">

--- a/docs/agents/sematext-agent/packages/configuration.md
+++ b/docs/agents/sematext-agent/packages/configuration.md
@@ -30,7 +30,7 @@ You can *disable* package collection by setting the following properties:
  </div>
 </div>
 
-Additionally, you can tweak the interval that determines how often packages are scanned. By default, the interval is every 10 minutes. The agent retrieves packages from the file system and any running containers, then compares the current state to decide which packages should be reported as installed or removed, and finally ships the events to Sematext Cloud. Asides from that, the agent proactively reacts to file system changes and bulks the packages in real time.
+Additionally, you can tweak the interval that determines how often packages are scanned. By default, the interval is every 10 minutes. The agent retrieves packages from the file system and any running containers, then compares the current state to decide which packages should be reported as installed or removed, and finally ships the events to Sematext Cloud. In addition to reading package info periodically, the agent also captures package install, update, and uninstall events and ships them in real time.
 
 <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
  <div class="mdl-tabs__tab-bar">

--- a/docs/agents/sematext-agent/packages/configuration.md
+++ b/docs/agents/sematext-agent/packages/configuration.md
@@ -1,0 +1,75 @@
+title: Configuring Package Collection
+description: Package Collection is enabled by default in the Sematext Agent configuration.
+
+Package Collection is enabled by default in the [Sematext Agent configuration](../agents/sematext-agent/containers/configuration/). It collects packages from two different sources:
+
+- packages installed on virtual/bare-metal hosts
+- packages residing inside containers
+
+You can *disable* package collection by setting the following properties:
+
+<div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
+ <div class="mdl-tabs__tab-bar">
+     <a href="#file-pkg-enabled" class="mdl-tabs__tab is-active">Config file</a>
+     <a href="#env-pkg-enabled" class="mdl-tabs__tab">Env variable</a>
+ </div>
+
+ <div class="mdl-tabs__panel is-active" id="file-pkg-enabled">
+   <pre>
+   # st-agent.yml
+   pkg:
+     enabled: false
+     container-enabled: false
+   </pre>
+ </div>
+ <div class="mdl-tabs__panel" id="env-pkg-enabled">
+   <pre>
+   PKG_ENABLED=false
+   PKG_CONTAINER_ENABLED=false
+   </pre>
+ </div>
+</div>
+
+Additionally, you can tweak the interval that determines how often packages are scanned. By default, every 10 minutes, the agent retrieves packages from the file system/running containers, compares the current state to decide which packages should be reported as installed or removed and finally ships the events to Sematext Cloud.
+
+<div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
+ <div class="mdl-tabs__tab-bar">
+     <a href="#file-pkg-interval" class="mdl-tabs__tab is-active">Config file</a>
+     <a href="#env-pkg-interval" class="mdl-tabs__tab">Env variable</a>
+ </div>
+
+ <div class="mdl-tabs__panel is-active" id="file-pkg-interval">
+   <pre>
+   # st-agent.yml
+   pkg:
+     interval: 10m
+   </pre>
+ </div>
+ <div class="mdl-tabs__panel" id="env-pkg-interval">
+   <pre>
+   PKG_INTERVAL=10m
+   </pre>
+ </div>
+</div>
+
+Some packages may include the list of configuration files (e.g. Debian packages). To instruct the agent to track the configuration files, you can use the following settings.
+
+<div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
+ <div class="mdl-tabs__tab-bar">
+     <a href="#file-pkg-configs" class="mdl-tabs__tab is-active">Config file</a>
+     <a href="#env-pkg-configs" class="mdl-tabs__tab">Env variable</a>
+ </div>
+
+ <div class="mdl-tabs__panel is-active" id="file-pkg-configs">
+   <pre>
+   # st-agent.yml
+   pkg:
+     configs-enabled: true
+   </pre>
+ </div>
+ <div class="mdl-tabs__panel" id="env-pkg-configs">
+   <pre>
+   CONFIGS_ENABLED=true
+   </pre>
+ </div>
+</div>

--- a/docs/agents/sematext-agent/packages/configuration.md
+++ b/docs/agents/sematext-agent/packages/configuration.md
@@ -30,7 +30,7 @@ You can *disable* package collection by setting the following properties:
  </div>
 </div>
 
-Additionally, you can tweak the interval that determines how often packages are scanned. By default, the interval is every 10 minutes. The agent retrieves packages from the file system and any running containers, then compares the current state to decide which packages should be reported as installed or removed, and finally ships the events to Sematext Cloud. Asides from that, the agent proactively reacts to the file system changes and bulks the packages in real time.
+Additionally, you can tweak the interval that determines how often packages are scanned. By default, the interval is every 10 minutes. The agent retrieves packages from the file system and any running containers, then compares the current state to decide which packages should be reported as installed or removed, and finally ships the events to Sematext Cloud. Asides from that, the agent proactively reacts to file system changes and bulks the packages in real time.
 
 <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
  <div class="mdl-tabs__tab-bar">

--- a/docs/agents/sematext-agent/packages/configuration.md
+++ b/docs/agents/sematext-agent/packages/configuration.md
@@ -30,7 +30,7 @@ You can *disable* package collection by setting the following properties:
  </div>
 </div>
 
-Additionally, you can tweak the interval that determines how often packages are scanned. By default, every 10 minutes, the agent retrieves packages from the file system/running containers, compares the current state to decide which packages should be reported as installed or removed and finally ships the events to Sematext Cloud.
+Additionally, you can tweak the interval that determines how often packages are scanned. By default, the interval is every 10 minutes. The agent retrieves packages from the file system and any running containers, then compares the current state to decide which packages should be reported as installed or removed, and finally ships the events to Sematext Cloud.
 
 <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
  <div class="mdl-tabs__tab-bar">
@@ -52,7 +52,7 @@ Additionally, you can tweak the interval that determines how often packages are 
  </div>
 </div>
 
-Some packages may include the list of configuration files (e.g. Debian packages). To instruct the agent to track the configuration files, you can use the following settings.
+Some packages may include the a list of configuration files (e.g. Debian packages). To instruct the agent to track the configuration files, you can use the following settings.
 
 <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect">
  <div class="mdl-tabs__tab-bar">

--- a/docs/agents/sematext-agent/packages/data.md
+++ b/docs/agents/sematext-agent/packages/data.md
@@ -8,6 +8,6 @@ Package payloads are comprised of various fields as summarized in the table. Sem
 | name          | Represents the package name |
 | version       | Is the version linked to the particular package |   
 | type          | Designates the type of the package (e.g. Python) |
-| architecture  | Determines the architecture the package was built (32/64 bits) |
+| architecture  | Determines the architecture for which the package was built (32/64 bits) |
 | configurations| Is the sequence of the configuration files tied to the package (only applicable for Debian-based packages) |
 | container id  | When a package is pulled from the container, this field is the identifier of the container where the package is located  |

--- a/docs/agents/sematext-agent/packages/data.md
+++ b/docs/agents/sematext-agent/packages/data.md
@@ -1,0 +1,13 @@
+title: Package Data
+description: Package Data collected by Sematext Agent
+
+Package payloads are comprised of various fields as summarized in the table. Sematext Agent currently supports Python, Node.js and Debian-based packages.
+
+| Name          | Description |
+| --------------|-------------|
+| name          | Represents the package name |
+| version       | Is the version linked to the particular package |   
+| type          | Designates the type of the package (e.g. Python) |
+| architecture  | Determines the architecture the package was built (32/64 bits) |
+| configurations| Is the sequence of the configuration files tied to the package (only applicable for Debian-based packages) |
+| container id  | When a package is pulled from the container, this field is the identifier of the container where the package is located  |

--- a/docs/monitoring/inventory.md
+++ b/docs/monitoring/inventory.md
@@ -3,7 +3,7 @@ description: Sematext Inventory Monitoring gives you insight into your whole inf
 
 The [Sematext Agent](../agents/sematext-agent) provides a simple and versatile way of gathering machine-related information such as host, VM, or container properties, kernel versions, and installed packages. It presents them on a per-host basis allowing you not only to view the data but also search and compare different hosts. All of this, in the same place, shipped automatically and effortlessly, without any operational overhead.
 
-The Inventory information is available in the *Monitoring Infrastructure* section of the *Monitoring* tab of your Sematext Cloud account - your main place for hosts, virtual machines and containers information. 
+The Inventory information is available in the *Monitoring Infrastructure* section of the *Monitoring* tab of your Sematext Cloud account - your main place for hosts, virtual machines and containers information.
 
 <!-- ![Sematext Inventory Main Screen](../images/monitoring/inventory_main_view.png) -->
 
@@ -66,19 +66,7 @@ The Agent checks the state of packages on machines and containers where it's run
 
 ## Enabling Inventory Monitoring
 
-To enable Inventory Monitoring you need to adjust your `st-agent.yml` file located in the `/opt/spm/properties` directory and set the following section:
-
-```
-pkg:
-  enabled: true
-  interval: 10m
-```
-
-After that the [Sematext Agent](../agents/sematext-agent) needs to be restarted by running the following command:
-
-```
-service spm-monitor-st-agent restart
-```
+Check out enabling and disabling Inventory Monitoring [here](../agents/sematext-agent/packages/configuration/).
 
 ## Gathered Data
 
@@ -104,6 +92,6 @@ In addition, the following information about packages is gathered for Node.js, P
 Here are some of the common use cases and issues that Inventory Monitoring helps solve:
 
 - Finding obsolete packages  
-- Seeing differences in environments for troubleshooting behavior discrepancies 
+- Seeing differences in environments for troubleshooting behavior discrepancies
 - Finding packages mentioned in the [CVE](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures) reports
 - And many, many more

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,7 +140,10 @@ pages:
           - Configuration: agents/sematext-agent/processes/configuration.md
           - Metrics: agents/sematext-agent/processes/metrics.md
           - Metadata: agents/sematext-agent/processes/metadata.md
-          - Sensitive Data: agents/sematext-agent/processes/sensitive-data.md 
+          - Sensitive Data: agents/sematext-agent/processes/sensitive-data.md
+        - Packages:
+          - Configuration: agents/sematext-agent/packages/configuration.md
+          - Data: agents/sematext-agent/packages/data.md
       - Infra & App Agent:
         - Overview:  agents/spm-client.md
         - Embedded Mode: agents/spm-monitor-javaagent.md


### PR DESCRIPTION
This PR adds a new section to explain available configuration options related to package collection. It also contains a new page that describes which package data is gathered.