### PR TITLE
Added Team and Access Sharing sections and guides

### DIFF
--- a/docs/team/account-access.md
+++ b/docs/team/account-access.md
@@ -8,3 +8,6 @@ hooks, alert rules, and integrations.
 To share your Account with other users, go to the 
 [Team page](https://apps.sematext.com/ui/team/accounts) on Sematext Cloud.
 
+<video style="display:block; width:100%; height:auto;" controls autoplay loop>
+  <source src="https://sematext.com/wp-content/uploads/2019/08/account-access.mp4" type="video/mp4" />
+</video>

--- a/docs/team/account-access.md
+++ b/docs/team/account-access.md
@@ -1,0 +1,10 @@
+title: Sematext Account Access
+description: Inviting team members to your account means they get access to all your Apps, dashboards, notification hooks, alert rules, and everything else!  
+
+By inviting a user to your Account, you invite them to your **whole account**, 
+so they get access to **all** your Apps, Dashboards, notification
+hooks, alert rules, and integrations.
+
+To share your Account with other users, go to the 
+[Team page](https://apps.sematext.com/ui/team/accounts) on Sematext Cloud.
+

--- a/docs/team/app-access.md
+++ b/docs/team/app-access.md
@@ -1,7 +1,7 @@
 title: Sematext App Access
 description: App Sharing is restricted only to a particular app. Nothing besides the shared app is accessible to the invited user for example, dashboards are at the account level can can thus be shared only through Account Sharing.
 
-App Access is **restricted only to a particular App**. Nothing besides the 
+App access is **restricted only to a particular App**. Nothing besides the 
 shared App is accessible to the invited user. 
 
 *__Note__: Dashboards are at the account level can can thus be shared only through Account Access.*
@@ -9,12 +9,12 @@ shared App is accessible to the invited user.
 This option is useful if you want to be restrictive about which Apps can be 
 seen by others or what kind of effect they have on your team. 
 
-By only configuring App Access, guests **can't see nor edit alert rules** created 
+By only configuring App access, guests **can't see or edit alert rules** created 
 by your team, they **can't use your team's notification hooks**, meaning they're 
 **limited only to the App they have access to**.
 
 To share one of your Apps with other users, go to the 
-[App Access page](https://apps.sematext.com/ui/team/accounts) on Sematext Cloud.
+[App access page](https://apps.sematext.com/ui/team/accounts) on Sematext Cloud.
 
 <video style="display:block; width:100%; height:auto;" controls autoplay loop>
   <source src="https://sematext.com/wp-content/uploads/2019/08/app-access.mp4" type="video/mp4" />

--- a/docs/team/app-access.md
+++ b/docs/team/app-access.md
@@ -1,6 +1,21 @@
 title: Sematext App Access
 description: App Sharing is restricted only to a particular app. Nothing besides the shared app is accessible to the invited user for example, dashboards are at the account level can can thus be shared only through Account Sharing.
 
+App Access is **restricted only to a particular App**. Nothing besides the 
+shared App is accessible to the invited user. 
 
-To share App, go
-to <https://apps.sematext.com/ui/team/apps>
+*__Note__: Dashboards are at the account level can can thus be shared only through Account Access.*
+
+This option is useful if you want to be restrictive about which Apps can be 
+seen by others or what kind of effect they have on your team. 
+
+By only configuring App Access, guests **can't see nor edit alert rules** created 
+by your team, they **can't use your team's notification hooks**, meaning they're 
+**limited only to the App they have access to**.
+
+To share one of your Apps with other users, go to the 
+[App Access page](https://apps.sematext.com/ui/team/accounts) on Sematext Cloud.
+
+<video style="display:block; width:100%; height:auto;" controls autoplay loop>
+  <source src="https://sematext.com/wp-content/uploads/2019/08/app-access.mp4" type="video/mp4" />
+</video>

--- a/docs/team/app-access.md
+++ b/docs/team/app-access.md
@@ -1,0 +1,6 @@
+title: Sematext App Access
+description: App Sharing is restricted only to a particular app. Nothing besides the shared app is accessible to the invited user for example, dashboards are at the account level can can thus be shared only through Account Sharing.
+
+
+To share App, go
+to <https://apps.sematext.com/ui/team/apps>

--- a/docs/team/app-transfer.md
+++ b/docs/team/app-transfer.md
@@ -2,7 +2,7 @@ title: Sematext App Transfer
 description: Inviting team members to your account means they get access to all your Apps, dashboards, notification hooks, alert rules, and everything else!
 
 No level of Access can change the Owner status of an App. To transfer the 
-ownership of an App, you need to use the App Transfer feature. Select an App and enter the user
+ownership of an App, use the App Transfer feature. Select an App, enter the user
 you wish to transfer the App to, and hit **Transfer**.
 
 To transfer one of your Apps to another user, go to the 

--- a/docs/team/app-transfer.md
+++ b/docs/team/app-transfer.md
@@ -1,0 +1,3 @@
+title: Sematext App Tranfser
+description: Inviting team members to your account means they get access to all your Apps, dashboards, notification hooks, alert rules, and everything else!
+

--- a/docs/team/app-transfer.md
+++ b/docs/team/app-transfer.md
@@ -1,3 +1,13 @@
-title: Sematext App Tranfser
+title: Sematext App Transfer
 description: Inviting team members to your account means they get access to all your Apps, dashboards, notification hooks, alert rules, and everything else!
 
+No level of Access can change the Owner status of an App. To transfer the 
+ownership of an App, you need to use the App Transfer feature. Select an App and enter the user
+you wish to transfer the App to, and hit **Transfer**.
+
+To transfer one of your Apps to another user, go to the 
+[App Transfer page](https://apps.test.sematext.com/ui/team/transfers) on Sematext Cloud.
+
+<video style="display:block; width:100%; height:auto;" controls autoplay loop>
+  <source src="https://sematext.com/wp-content/uploads/2019/08/app-transfer.mp4" type="video/mp4" />
+</video>

--- a/docs/team/index.md
+++ b/docs/team/index.md
@@ -1,0 +1,90 @@
+title: Sematext Team and Access Sharing
+description: There are two levels of access rights. Account and App Access. Inviting team members to your account means they get access to all your Apps, Dashboards, notification hooks, alert rules, and everything else! You can invite team members to individual Apps and access Apps you’ve been invited to. 
+
+
+There are two levels of access rights: 
+
+- **Account Access** - invite others to your **whole account**
+- **App Access** - invite others **only to a particular App**
+
+And a third option called:
+
+- **App Transfer** - transferring ownership status of an App to another user
+
+You can assign three different Roles for users you give access to your account 
+or particular Apps:
+
+- **User**
+- **Admin**
+- **Billing Admin**
+
+And a fourth option: 
+
+- **Owner** - assigned if you transfer the ownership of an App to another user.
+
+
+## Account vs. App Access
+Account Access and App Access are not exclusive. You can use both of
+these two access types at the same time. You could share your Account with
+some users, and share specific Apps with other users.
+
+## Account Access
+By inviting a user to your Account, you invite them to your **whole account**, 
+so they get access to **all** your Apps, Dashboards, notification
+hooks, alert rules, and integrations.
+
+They can also create new Apps under your account and invite other users. 
+Depending on the role you assign to invitees, they may be able to administer 
+your Apps, Dashboards, users and even billing info (change app plan, assign 
+credit card, etc). 
+
+Account Sharing is very convenient because as soon as a new
+Sematext App is added to your account or new Dashboard is created, all
+users added to your account get access to it. Of course, the level of
+access depends on the role you initially assigned to each person.
+
+
+## App Access
+App Access is **restricted only to a particular App**. Nothing besides the 
+shared App is accessible to the invited user. 
+
+*__Note__: Dashboards are at the account level can can thus be shared only through Account Access.*
+
+This option is useful if you want to be restrictive about which Apps can be 
+seen by others or what kind of effect they have on your team. 
+
+By only configuring App Access, guests **can't see nor edit alert rules** created 
+by your team, they **can't use your team's notification hooks**, meaning they're 
+**limited only to the App they have access to**.
+
+## App Transfer
+No level of Access can change the Owner status of an App. To transfer the 
+ownership of an App, you need to use the App Transfer feature. Select an App and enter the user
+you wish to transfer the App to, and hit **Transfer**.
+
+## Typical use of Roles in an Organization
+Typically you might have one person create an account by [signing up](https://apps.sematext.com/ui/registration). 
+This account might be considered a _parent_ account for your whole organization.  
+
+### Owner
+Since the person who created the account would be its `OWNER`, this person
+is typically a team leader or manager, somebody with the responsibility to 
+oversee the DevOps pipeline of the whole organization. They might then choose 
+to share the whole Account with every other person from the team/organization 
+to allow others to easily access all Apps created under that account.
+
+### Admin
+Some invited users might be given the `ADMIN` role, which gives
+them read, write, and invite rights. 
+
+### User
+Other invitees might get the
+`USER` role, which mostly only grants read rights with the ability to
+create and edit their own Dashboards/Alerts/Subscriptions which are
+available to everyone under the shared account. 
+
+### Billing Admin
+In some cases, the account `OWNER` will not be able to handle billing-related 
+info and will want to invite `BILLING_ADMIN`s who will be able to define, 
+edit, and delete credit cards and choose plans to be used for Apps in the 
+account.

--- a/docs/team/index.md
+++ b/docs/team/index.md
@@ -66,25 +66,8 @@ you wish to transfer the App to, and hit **Transfer**.
 Typically you might have one person create an account by [signing up](https://apps.sematext.com/ui/registration). 
 This account might be considered a _parent_ account for your whole organization.  
 
-### Owner
-Since the person who created the account would be its `OWNER`, this person
-is typically a team leader or manager, somebody with the responsibility to 
-oversee the DevOps pipeline of the whole organization. They might then choose 
-to share the whole Account with every other person from the team/organization 
-to allow others to easily access all Apps created under that account.
-
-### Admin
-Some invited users might be given the `ADMIN` role, which gives
-them read, write, and invite rights. 
-
-### User
-Other invitees might get the
-`USER` role, which mostly only grants read rights with the ability to
-create and edit their own Dashboards/Alerts/Subscriptions which are
-available to everyone under the shared account. 
-
-### Billing Admin
-In some cases, the account `OWNER` will not be able to handle billing-related 
-info and will want to invite `BILLING_ADMIN`s who will be able to define, 
-edit, and delete credit cards and choose plans to be used for Apps in the 
+- **Owner** - the person who created the account would be its `OWNER`
+- **Admin** - invited users can be given the `ADMIN` role, which gives them read, write, and invite rights 
+- **User** - the `USER` role grants almost entirely read rights
+- **Billing Admin** - the `BILLING_ADMIN` is able to define, edit, and delete credit cards and choose plans to be used for Apps in the 
 account.

--- a/docs/team/index.md
+++ b/docs/team/index.md
@@ -24,12 +24,12 @@ And a fourth option:
 
 
 ## Account vs. App Access
-Account Access and App Access are not exclusive. You can use both of
-these two access types at the same time. You could share your Account with
+Account access and App access are not exclusive. You can use both of
+these two access types at the same time. You could share your account with
 some users, and share specific Apps with other users.
 
 ## Account Access
-By inviting a user to your Account, you invite them to your **whole account**, 
+By inviting a user to your account, you invite them to your **whole account**, 
 so they get access to **all** your Apps, Dashboards, notification
 hooks, alert rules, and integrations.
 
@@ -41,33 +41,33 @@ credit card, etc).
 Account Sharing is very convenient because as soon as a new
 Sematext App is added to your account or new Dashboard is created, all
 users added to your account get access to it. Of course, the level of
-access depends on the role you initially assigned to each person.
+access depends on the role you assigned to each person.
 
 
 ## App Access
 App Access is **restricted only to a particular App**. Nothing besides the 
 shared App is accessible to the invited user. 
 
-*__Note__: Dashboards are at the account level can can thus be shared only through Account Access.*
+*__Note__: Dashboards are at the account level and can thus be shared only through account Access.*
 
 This option is useful if you want to be restrictive about which Apps can be 
-seen by others or what kind of effect they have on your team. 
+seen by others or what kind of changes they can make. 
 
-By only configuring App Access, guests **can't see nor edit alert rules** created 
+By only configuring App Access, guests **can't see or edit alert rules** created 
 by your team, they **can't use your team's notification hooks**, meaning they're 
 **limited only to the App they have access to**.
 
 ## App Transfer
 No level of Access can change the Owner status of an App. To transfer the 
-ownership of an App, you need to use the App Transfer feature. Select an App and enter the user
+ownership of an App, use the App Transfer feature. Select an App, enter the user
 you wish to transfer the App to, and hit **Transfer**.
 
-## Typical use of Roles in an Organization
+## Typical use of Roles in an Organization or Team
 Typically you might have one person create an account by [signing up](https://apps.sematext.com/ui/registration). 
-This account might be considered a _parent_ account for your whole organization.  
+This account might be considered a _parent_ account for your whole organization or team.  
 
 - **Owner** - the person who created the account would be its `OWNER`
 - **Admin** - invited users can be given the `ADMIN` role, which gives them read, write, and invite rights 
-- **User** - the `USER` role grants almost entirely read rights
+- **User** - the `USER` role grants read rights and limited write rights
 - **Billing Admin** - the `BILLING_ADMIN` is able to define, edit, and delete credit cards and choose plans to be used for Apps in the 
 account.

--- a/docs/team/user-roles.md
+++ b/docs/team/user-roles.md
@@ -2,12 +2,12 @@ title: Sematext User Roles
 description: Inviting team members to your account means they get access to all your Apps, dashboards, notification hooks, alert rules, and everything else!
 
 Typically you might have one person create an account by [signing up](https://apps.sematext.com/ui/registration). 
-This account might be considered a _parent_ account for your whole organization.  
+This account might be considered a _parent_ account for your whole organization or team.  
 
 ### Owner
 Since the person who created the account would be its `OWNER`, this person
 is typically a team leader or manager, somebody with the responsibility to 
-oversee the DevOps pipeline of the whole organization. They might then choose 
+oversee the DevOps pipeline of the whole organization or team. They might then choose 
 to share the whole Account with every other person from the team/organization 
 to allow others to easily access all Apps created under that account.
 

--- a/docs/team/user-roles.md
+++ b/docs/team/user-roles.md
@@ -1,0 +1,44 @@
+title: Sematext User Roles
+description: Inviting team members to your account means they get access to all your Apps, dashboards, notification hooks, alert rules, and everything else!
+
+**What is the difference between OWNER, ADMIN, BILLING_ADMIN, and USER roles?**
+
+There are 3 common roles available when Sharing Account and
+Sharing App (**OWNER**, **ADMIN**, **USER**), and one role which is
+specific only to Account Sharing (**BILLING_ADMIN**).  
+  
+Each account has one OWNER (if you created some account, you are its
+OWNER). Each app also has one OWNER (The OWNER of an app is OWNER of
+account under which some app was created. If you create an app under
+your account, you are the OWNER of that app. If some user with whom
+you've shared your account creates a new app under your account, you are
+again the OWNER of that app. However, if that user creates a new app
+under his own account, he will be its OWNER).  
+  
+Each account and app can have 0 or more ADMINS and USERS. If you added
+some user as ADMIN to your account, he also automatically gets the ADMIN
+role for all your apps (account role is transitive to app role).  
+  
+ADMIN users can modify everything under your account/app except billing
+related info. They can: create/delete/update all
+dashboards/alerts/subscriptions/users... Users with USER role have read
+rights on everything except billing info (they can view all reports,
+dashboards, alerts...). They can even create/edit their own alerts and
+subscriptions on apps from shared account (but can't edit other user's
+alerts/subscriptions, only ADMINs can do that). If they were added to an
+Account (not to an App), they can also create their own dashboards and
+add other USERs to your account.  
+  
+There is a special role available when Sharing Account - BILLING_ADMIN.
+This role has all rights as the standard ADMIN, but can also access/edit
+billing-related info. The only thing this role cannot do is change
+password of your account.
+
+**When would I want to add someone as BILLING_ADMIN?**
+
+When you don't have a credit card that should be used for
+charging, but some other person has it, you should invite this person
+and give them the BILLING_ADMIN role. Similarly, if you created an
+account and defined a credit card, but now want somebody else to take
+care of all billing related activity (assigning plans and credit cards
+to various apps), you'd give them the BILLING_ADMIN role.

--- a/docs/team/user-roles.md
+++ b/docs/team/user-roles.md
@@ -1,44 +1,28 @@
 title: Sematext User Roles
 description: Inviting team members to your account means they get access to all your Apps, dashboards, notification hooks, alert rules, and everything else!
 
-**What is the difference between OWNER, ADMIN, BILLING_ADMIN, and USER roles?**
+Typically you might have one person create an account by [signing up](https://apps.sematext.com/ui/registration). 
+This account might be considered a _parent_ account for your whole organization.  
 
-There are 3 common roles available when Sharing Account and
-Sharing App (**OWNER**, **ADMIN**, **USER**), and one role which is
-specific only to Account Sharing (**BILLING_ADMIN**).  
-  
-Each account has one OWNER (if you created some account, you are its
-OWNER). Each app also has one OWNER (The OWNER of an app is OWNER of
-account under which some app was created. If you create an app under
-your account, you are the OWNER of that app. If some user with whom
-you've shared your account creates a new app under your account, you are
-again the OWNER of that app. However, if that user creates a new app
-under his own account, he will be its OWNER).  
-  
-Each account and app can have 0 or more ADMINS and USERS. If you added
-some user as ADMIN to your account, he also automatically gets the ADMIN
-role for all your apps (account role is transitive to app role).  
-  
-ADMIN users can modify everything under your account/app except billing
-related info. They can: create/delete/update all
-dashboards/alerts/subscriptions/users... Users with USER role have read
-rights on everything except billing info (they can view all reports,
-dashboards, alerts...). They can even create/edit their own alerts and
-subscriptions on apps from shared account (but can't edit other user's
-alerts/subscriptions, only ADMINs can do that). If they were added to an
-Account (not to an App), they can also create their own dashboards and
-add other USERs to your account.  
-  
-There is a special role available when Sharing Account - BILLING_ADMIN.
-This role has all rights as the standard ADMIN, but can also access/edit
-billing-related info. The only thing this role cannot do is change
-password of your account.
+### Owner
+Since the person who created the account would be its `OWNER`, this person
+is typically a team leader or manager, somebody with the responsibility to 
+oversee the DevOps pipeline of the whole organization. They might then choose 
+to share the whole Account with every other person from the team/organization 
+to allow others to easily access all Apps created under that account.
 
-**When would I want to add someone as BILLING_ADMIN?**
+### Admin
+Some invited users might be given the `ADMIN` role, which gives
+them read, write, and invite rights. 
 
-When you don't have a credit card that should be used for
-charging, but some other person has it, you should invite this person
-and give them the BILLING_ADMIN role. Similarly, if you created an
-account and defined a credit card, but now want somebody else to take
-care of all billing related activity (assigning plans and credit cards
-to various apps), you'd give them the BILLING_ADMIN role.
+### User
+Other invitees might get the
+`USER` role, which mostly only grants read rights with the ability to
+create and edit their own Dashboards/Alerts/Subscriptions which are
+available to everyone under the shared account. 
+
+### Billing Admin
+In some cases, the account `OWNER` will not be able to handle billing-related 
+info and will want to invite `BILLING_ADMIN`s who will be able to define, 
+edit, and delete credit cards and choose plans to be used for Apps in the 
+account.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,12 @@ pages:
       - Slack: integration/alerts-slack-integration.md
       - VictorOps: integration/alerts-victorops-integration.md
       - Zapier: integration/alerts-zapier-integration.md
+    - Team:
+      - Overview: team/index.md
+      - Account Access: team/account-access.md
+      - App Access: team/app-access.md
+      - App Transfer: team/app-transfer.md
+      - User Roles: team/user-roles.md
     - Agents:
       - Overview: agents/index.md
       - Sematext Agent:


### PR DESCRIPTION
Took the copy from FAQ and created a dedicated section for Team and Access Sharing, with pages for:
- Overview
- Account Access
- App Access
- App Transfer
- User Roles