### PR TITLE
SC-5756 added container diag instructions; deduplicated some old stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /site
+/.project

--- a/docs/guide/integrations-guide.md
+++ b/docs/guide/integrations-guide.md
@@ -185,15 +185,17 @@ We accept JSON messages using any log shipper and any logging library, as long a
 
 ### Monitoring
 
-When creating a monitoring app two steps are required, Agent Installation and Agent Setup.
+Two steps are required when creating a Monitoring App:
+- Agent Installation
+- Agent Setup
 
 #### Agent Installation
 
-You need to add Sematext repository and install Sematext monitoring agent. It is available for various Linux distributions as well as infrastructure orchestration tools like Ansible, Puppet, and Chef. Choose your distribution and install required packages. Once installed, move to the next step, that is, agent configuration setup
+You need to add the Sematext repository and install Sematext Monitoring Agent. It is available for various Linux distributions as well as infrastructure orchestration tools like Ansible, Puppet, and Chef. Choose your distribution and install required packages. Once installed, move to the Agent Setup step.
 
 #### Agent Setup
 
-Sematext Monitor agent collects performance metrics of your application (Solr, Elasticsearch, HBase...). It can run in two different modes: 
+Sematext Monitoring Agent collects performance metrics of your application (Solr, Elasticsearch, HBase...). It can run in two different modes: 
 
 - [In-process as a javaagent](/agents/spm-monitor-javaagent/)
 - [Standalone as a separate process](/agents/spm-monitor-standalone/) 

--- a/docs/guide/integrations-guide.md
+++ b/docs/guide/integrations-guide.md
@@ -185,13 +185,13 @@ We accept JSON messages using any log shipper and any logging library, as long a
 
 ### Monitoring
 
-When creating a monitoring app two steps are required, package installation and agent configuration setup.
+When creating a monitoring app two steps are required, Agent Installation and Agent Setup.
 
-#### Package Installation
+#### Agent Installation
 
 You need to add Sematext repository and install Sematext monitoring agent. It is available for various Linux distributions as well as infrastructure orchestration tools like Ansible, Puppet, and Chef. Choose your distribution and install required packages. Once installed, move to the next step, that is, agent configuration setup
 
-#### Agent Configuration Setup
+#### Agent Setup
 
 Sematext Monitor agent collects performance metrics of your application (Solr, Elasticsearch, HBase...). It can run in two different modes: 
 

--- a/docs/integration/kafka.md
+++ b/docs/integration/kafka.md
@@ -163,13 +163,8 @@ The Sematext Kafka monitoring agent collects the following metrics.
 
 ## Troubleshooting
 
-If you are having issues with Sematext Monitoring, i.e. not seeing Kafka metrics, you can create a diagnostics package on any affected machines where Kafka Monitoring Agent installed by running:
-
-```bash
-sudo bash /opt/spm/bin/spm-client-diagnostics.sh
-```
-
-The resulting package will contain all relevant info needed for our investigation. You can send it, along with a short description of your problem, to support@sematext.com or contact us through the chat in the bottom right.
+If you are having issues with Sematext Monitoring, i.e. not seeing Kafka metrics, see
+[How do I create the diagnostics package](/monitoring/spm-faq/#how-do-i-create-the-diagnostics-package).
 
 For more troubleshooting information look at [Troubleshooting](/monitoring/spm-faq/#troubleshooting) section.
 

--- a/docs/integration/mongodb.md
+++ b/docs/integration/mongodb.md
@@ -21,14 +21,8 @@ Sematext MongoDB monitoring agent is an open-source [mongodb monitoring agent](h
 
 ** Generate diagnostics file for Sematext Support **
 
-If you are not seeing some or all MongoDB metrics, create a
-"diagnostics dump" and contact us via chat or email. To create the
-diagnostics dump just run the following in your application directory:
-
-    spm-client-diagnostics
-
-The output of this script points to the ZIP file and shows the Sematext
-Support email address to which the ZIP file should be sent. 
+If you are not seeing some or all MongoDB metrics, see
+[How do I create the diagnostics package](/monitoring/spm-faq/#how-do-i-create-the-diagnostics-package).
 
 ** Using Sematext for monitoring MongoDB behind Firewalls / Proxy servers **
 

--- a/docs/integration/solr.md
+++ b/docs/integration/solr.md
@@ -97,13 +97,8 @@ The Sematext Solr monitoring agent collects the following metrics.
 
 ## Troubleshooting
 
-If you are having issues with Sematext Monitoring, i.e. not seeing SolrCloud metrics, you can create a diagnostics package on any affected machines where SolrCloud Monitoring Agent installed by running:
-
-```bash
-sudo bash /opt/spm/bin/spm-client-diagnostics.sh
-```
-
-The resulting package will contain all relevant info needed for our investigation. You can send it, along with a short description of your problem, to support@sematext.com or contact us through the chat in the bottom right.
+If you are having issues with Sematext Monitoring, i.e. not seeing SolrCloud metrics, see
+[How do I create the diagnostics package](/monitoring/spm-faq/#how-do-i-create-the-diagnostics-package).
 
 For more troubleshooting information please look at [Troubleshooting](/monitoring/spm-faq/#troubleshooting) section.
 

--- a/docs/integration/solrcloud.md
+++ b/docs/integration/solrcloud.md
@@ -94,13 +94,8 @@ The Sematext SolrCloud monitoring agent collects the following metrics.
 
 ## Troubleshooting
 
-If you are having issues with Sematext Monitoring, i.e. not seeing SolrCloud metrics, you can create a diagnostics package on any affected machines where SolrCloud Monitoring Agent installed by running:
-
-```bash
-sudo bash /opt/spm/bin/spm-client-diagnostics.sh
-```
-
-The resulting package will contain all relevant info needed for our investigation. You can send it, along with a short description of your problem, to support@sematext.com or contact us through the chat in the bottom right.
+If you are having issues with Sematext Monitoring, i.e. not seeing SolrCloud metrics, see
+[How do I create the diagnostics package](/monitoring/spm-faq/#how-do-i-create-the-diagnostics-package).
 
 For more troubleshooting information please look at [Troubleshooting](/monitoring/spm-faq/#troubleshooting) section.
 

--- a/docs/monitoring/spm-faq.md
+++ b/docs/monitoring/spm-faq.md
@@ -582,7 +582,7 @@ At the moment there is no diagnostics script for container setups, so various re
 Two types of agents are running in container setups and spawn from the following images:
   - <b>sematext/agent</b> (also known as STA) - collects infrastructure data (OS and container info, metrics and events)
   - <b>sematext/app-agent</b> (known as application agent or AA) - collects application metrics (e.g. metrics of your Elasticsearch or Kafka).
-    For each monitored service instance one such application agent container will exist. These containers are created automatically by STA.
+    For each monitored service instance one such application agent container will exist. These containers are automatically created and managed by STA.
 
 <b>sematext/agent</b>
 
@@ -603,12 +603,12 @@ Kubernetes:
 This will produce multiple tgz files in /tmp dir, one for each running sematext/agent instance:
 
 ```
-for pod in $(kubectl get --no-headers -o=custom-columns=NAME:.metadata.name pods --selector=app=sematext-agent);do kubectl logs $pod -c agent | gzip > /tmp/st-agent-$pod.gz;done
+for pod in $(kubectl get --no-headers -o=custom-columns=NAME:.metadata.name pods --selector=app=sematext-agent);do kubectl logs $pod -c agent | gzip -9 > /tmp/st-agent-$pod.gz;done
 ```
 
 <b>sematext/app-agent</b>
 
-App Agent is writing multiple logs to container file system. You can list all App Agent pods with:
+App Agent writes multiple logs to container file system. You can list all App Agent pods with:
   - Docker/Swarm: `sudo docker ps -f ancestor=sematext/app-agent`
   - Kubernetes: `kubectl get pods --selector=service=st-aa`
 

--- a/docs/monitoring/spm-faq.md
+++ b/docs/monitoring/spm-faq.md
@@ -145,7 +145,7 @@ names), so this is adjusted command for solr1 instance.
 In the remaining sub-steps of "Agent Setup", replace
 word "**default**" with the jvm-name value you just used.
 
-"Agent Setup" step will have to be repeated N times,
+"Agent Setup" step will have to be repeated several times,
 once for each monitored application (in our example 3 times with 3
 different jvm-name values).
 
@@ -860,8 +860,8 @@ Note:
   - if you are installing SPM client for the first time
     and you want to be 100% sure its original hostname never leaves your
     network, define your hostname alias in `agent.properties`
-    file immediately after you complete "Agent Installation" step
-    and before you begin with "Agent Setup" step
+    file immediately after you complete the "Agent Installation" step
+    and before you begin with the "Agent Setup" step
     (installation instructions can be accessed from
     <https://apps.sematext.com/ui/monitoring>, click Actions \> Install
     Monitor on app you are installing)

--- a/docs/monitoring/spm-faq.md
+++ b/docs/monitoring/spm-faq.md
@@ -124,8 +124,8 @@ Monitor for app you are installing) for each of them separately.
 
 2.  If you want them monitored under the same Monitoring App (e.g., you
 have 3 Solr instances running on a server), you must use different JVM
-name for each of them. To do this, "1. Package installation" step should
-be run only once on this machine, while "2. Client configuration setup"
+name for each of them. To do this, "Agent Installation" step should
+be run only once on this machine, while "Agent Setup"
 step should be run once for each of the 3 Solr instances (installation
 instructions are accessible
 from <https://apps.sematext.com/ui/monitoring>, click Actions \> Install
@@ -142,10 +142,10 @@ In this example, we are setting up things for 3 separate Solr processes,
 monitored under JVM names: solr1, solr2 and solr3 (you choose any
 names), so this is adjusted command for solr1 instance.
 
-In the remaining sub-steps of "2. Client configuration setup", replace
+In the remaining sub-steps of "Agent Setup", replace
 word "**default**" with the jvm-name value you just used.
 
-"2. Client configuration setup" step will have to be repeated N times,
+"Agent Setup" step will have to be repeated N times,
 once for each monitored application (in our example 3 times with 3
 different jvm-name values).
 
@@ -448,7 +448,7 @@ sudo service spm-monitor restart
 
 **Note**: In case of **Memcached**, **Apache** and plain **Nginx** -
 after completing upgrade steps described above, you must also run
-commands described in Step 2 - Client Configuration Setup (which is
+commands described in "Agent Setup" (which is
 accessible from <https://apps.sematext.com/ui/monitoring>, click
 Actions \> Install Monitor for app you have installed)
 
@@ -559,6 +559,10 @@ with curl is failing, add `-k` flag.
 
 <a name="how-do-i-create-the-diagnostics-package" href="#how-do-i-create-the-diagnostics-package" class="faq-questions"><strong>How do I create the diagnostics package?</strong></a>
 
+Preparing diagnostics data differs depending on the setup you have.
+
+<b>Classic installation (rpm/deb packages)</b>
+
 If you are having issues with Sematext Monitoring, you can
 create diagnostics package on affected machines where SPM client was
 installed by running:
@@ -571,24 +575,65 @@ The resulting package will contain all relevant info needed for our
 investigation. You can send it, along with short description of your
 problem, to <support@sematext.com> or contact us in chat.
 
+<b>Container setups</b>
+
+At the moment there is no diagnostics script for container setups, so various resources have to be gathered manually.
+
+Two types of agents are running in container setups:
+  - <b>sematext/agent</b> (also known as STA) - collects infrastructure data (OS and container info, metrics and events)
+  - <b>sematext/app-agent</b> (known as application agent or AA) - collects application metrics (e.g. metrics of your Elasticsearch or Kafka).
+    For each monitored service instance one such application agent container will exist. These containers are created automatically by STA.
+
+<b>sematext/agent</b>
+
+Docker:
+
+```
+sudo docker logs st-agent > /tmp/st-agent.log 2>&1 && tar -cvzf /tmp/st-agent.tgz /tmp/st-agent.log
+```
+
+Swarm:
+
+```
+sudo docker service logs st-agent > /tmp/st-agent.log 2>&1 && tar -cvzf /tmp/st-agent.tgz /tmp/st-agent.log
+```
+
+Kubernetes:
+
+This will produce multiple tgz files in /tmp dir, one for each running sematext/agent instance:
+
+```
+for pod in $(kubectl get --no-headers -o=custom-columns=NAME:.metadata.name pods --selector=app=sematext-agent);do kubectl logs $pod -c agent | gzip > /tmp/st-agent-$pod.gz;done
+```
+
+<b>sematext/app-agent</b>
+
+App Agent is writing multiple logs to container file system. You can list all App Agent pods with:
+  - Docker/Swarm: `sudo docker ps -f ancestor=sematext/app-agent`
+  - Kubernetes: `kubectl get pods --selector=service=st-aa`
+
+You will notice that each App Agent container/pod name matches the name of the monitored service (e.g. service `my_service-7db849967c-kdmgz` will have associated App Agent container/pod `my_service-7db849967c-kdmgz-aa-mqdt9`). When you find the problematic App Agent, you can copy (using e.g. `docker cp` or `kubectl cp` command):
+  - its config file from /opt/spm/spm-monitor/conf dir
+  - its spm-monitor and spm-monitor-stats logs from `/opt/spm/spm-monitor/logs/apps/YOUR_TOKEN/MONITORED_SERVICE_POD_NAME` dir
+ 
+We will need all these files for investigation. You can send them, along with short description of your
+problem, to <support@sematext.com> or contact us in chat.
+
+
 <a name="i-see-only-my-system-metrics-e.g.-cpu-memory-network-disk-but-where-is-the-rest-of-my-data" href="#i-see-only-my-system-metrics-e.g.-cpu-memory-network-disk-but-where-is-the-rest-of-my-data" class="faq-questions"><strong>I see only my system metrics (e.g. CPU, Memory, Network, Disk...), but where is the rest of my data?</strong></a>
 
 Make sure you have followed all steps listed on [installation instructions page](https://apps.sematext.com/ui/monitoring).
-**Package installation** steps should be done first, followed by
-**Client configuration setup**. If you have done that and you still
-don't see application metrics, run ```sudo
-bash /opt/spm/bin/spm-client-diagnostics.sh``` to generate diagnostics
-package and send it to <support@sematext.com> with description of
-your problem.
+**Agent Installation** steps should be done first, followed by
+**Agent Setup**. If you have done that and you still
+don't see application metrics, see
+[How do I create the diagnostics package](spm-faq/#how-do-i-create-the-diagnostics-package).
 
 <a name="i-do-not-see-any-system-metrics-cpu-memory-network-disk-what-could-be-the-problem" href="#i-do-not-see-any-system-metrics-cpu-memory-network-disk-what-could-be-the-problem" class="faq-questions"><strong>I do not see any system metrics (e.g. CPU, Memory, Network, Disk), what could be the problem?</strong></a>
 
 Make sure you have followed all steps listed on [installation instructions page](https://apps.sematext.com/ui/monitoring). It
-is possible you missed **Client configuration setup** step. If you have
-done that and you still don't see application metrics, run ```sudo
-bash /opt/spm/bin/spm-client-diagnostics.sh``` to generate diagnostics
-package and send it to <support@sematext.com> with description of
-your problem.
+is possible you missed **Agent Setup** step. If you have
+done that and you still don't see application metrics, see
+[How do I create the diagnostics package](spm-faq/#how-do-i-create-the-diagnostics-package).
 
 <a name="i-am-using-trying-to-monitor-solr-elasticsearch-my-request-rate-and-latency-charts-are-empty" href="#i-am-using-trying-to-monitor-solr-elasticsearch-my-request-rate-and-latency-charts-are-empty" class="faq-questions"><strong>I am using trying to monitor Solr / Elasticsearch. My Request Rate and Latency charts are empty?</strong></a>
 
@@ -712,9 +757,7 @@ Restart SPM monitor after the above changes.
     version of monitor, make sure -D and -javaagent definitions occur
     before "-jar start.jar" part in your command
 
-8.  If none of the suggestions helped, run ```sudo bash
-    /opt/spm/bin/spm-client-diagnostics.sh``` to generate diagnostics
-    package and send it to <support@sematext.com>
+8.  If none of the suggestions helped, see [How do I create the diagnostics package](spm-faq/#how-do-i-create-the-diagnostics-package).
 
 <a name="my-server-stopped-sending-metrics-so-why-do-i-still-see-it-under-hosts-filter" href="#my-server-stopped-sending-metrics-so-why-do-i-still-see-it-under-hosts-filter" class="faq-questions"><strong>My server stopped sending metrics, so why do I still see it under Hosts Filter?</strong></a>
 
@@ -817,8 +860,8 @@ Note:
   - if you are installing SPM client for the first time
     and you want to be 100% sure its original hostname never leaves your
     network, define your hostname alias in `agent.properties`
-    file immediately after you complete "1. Package installation" step
-    and before you begin with "2. Client configuration setup" step
+    file immediately after you complete "Agent Installation" step
+    and before you begin with "Agent Setup" step
     (installation instructions can be accessed from
     <https://apps.sematext.com/ui/monitoring>, click Actions \> Install
     Monitor on app you are installing)

--- a/docs/monitoring/spm-faq.md
+++ b/docs/monitoring/spm-faq.md
@@ -579,7 +579,7 @@ problem, to <support@sematext.com> or contact us in chat.
 
 At the moment there is no diagnostics script for container setups, so various resources have to be gathered manually.
 
-Two types of agents are running in container setups:
+Two types of agents are running in container setups and spawn from the following images:
   - <b>sematext/agent</b> (also known as STA) - collects infrastructure data (OS and container info, metrics and events)
   - <b>sematext/app-agent</b> (known as application agent or AA) - collects application metrics (e.g. metrics of your Elasticsearch or Kafka).
     For each monitored service instance one such application agent container will exist. These containers are created automatically by STA.


### PR DESCRIPTION
This PR adjusts docs:
- adds instructions how to gather agent logs in container environments
- de-duplicates mentions of "create diagnostics package" by linking them to single FAQ entry that covers everything
- adjusts some naming to match recent changes in SC (Package Installation -> Agent Installation AND Client/Agent Configuration Setup -> Agent Setup)
