### PR TITLE
Removed an old, incomplete list of filters

### DIFF
--- a/docs/logagent/filters.md
+++ b/docs/logagent/filters.md
@@ -132,10 +132,3 @@ outputFilter:
               }
             }
 ```
-
-### List of available filters
-
-- [Grep input filter](./input-filter-grep) - module alias "grep"
-- [Grok input filter](./input-filter-grok) - module alias "grok"
-- [SQL output filter](./output-filter-sql) - module alias "sql"
-- [Access Watch output filter](./output-filter-accesswatch) - module alias "access-watch"


### PR DESCRIPTION
Removing this list because we have separate pages for input and output filters and we don't want to have this outdated and incomplete list here.