### PR TITLE
SC-8659: Added logs docs for IBM Cloud Kubernetes Service

### DIFF
--- a/docs/integration/ibm-cloud-kubernetes-logs.md
+++ b/docs/integration/ibm-cloud-kubernetes-logs.md
@@ -122,7 +122,8 @@ You don't need to change anything as all the config is in `logagent.conf`, just 
 kubectl create -f ibm-cloud-logagent-with-config-ds.yml
 ```
 
-When you want to edit the config, change the `logagent.conf`, recreate the ConfigMap, restart the Logagent pod to grab the new ConfigMap and you're done!
+**When you want to edit the config, change the `logagent.conf`, recreate the ConfigMap, restart the Logagent pod to grab the new ConfigMap and you're done!**
+
 Continue reading below to see how to configure more advanced settings.
 
 ### Drop Noisy Container Logs 
@@ -247,3 +248,6 @@ This config will route all audit logs to your Kubernetes Audit Logs App and the 
 _Note: Here's how you find the token after you create a Kubernetes Audit Logs App._
 ![](https://sematext.com/wp-content/uploads/2020/07/apps.sematext.com_ui_integrations_apps_33306_integrations_overview_activeSectionkubernetes-audit-dynamic.png)
 
+## Need more help?
+
+This was a brief overview of how to configure logging for IBM Cloud Kubernetes Service. If you have any more questions, feel free to reach out through the live chat or [Twitter @sematext](https://twitter.com/sematext)!

--- a/docs/integration/ibm-cloud-kubernetes-logs.md
+++ b/docs/integration/ibm-cloud-kubernetes-logs.md
@@ -1,8 +1,57 @@
 title: IBM Cloud Kubernetes Logs Integration
 description: Sematext IBM Cloud Kubernetes Logs integration is configured by running Logagent as a Daemonset in your cluster.
 
-Sematext offers a Kubernetes Audit logs receiver endpoint. Everything you need to do is to configure the Kubernetes API Server to send logs to it.
+With this integration you can:
 
-## Sematext Kubernetes Audit Logs Quick Start
+- Forward all container logs
+- Use log globs to choose which containers to log
+- Drop noisy logs with `dropEvents`
+- Forward logs to different Apps
+- Enable Kubernetes audit logs 
 
-Kubernetes audit logs are detailed descriptions of each call made to the Kubernetes API Server. They provide a chronological sequence of activities that lead to the state of the system at a specific moment. They are extremely useful for security and compliance purposes, telling you exactly who did what, when, and how. You can configure Kubernetes Audit Logs by using any of the two options below.
+IBM Cloud Kubernetes uses cointainerd as the container engine. In this case Logagent can't use the Docker remote API to retrieve logs and metadata. Instead, logs are collected from containerd log files, which requires access to the relevant directories.
+
+The Logagent [input-filter for Containerd](../logagent/input-filter-containerd/) supports:
+
+* Tailing log files from `/var/log/containers/`, `/var/log/pods` and `/var/data/kubeletlogs`
+* Enrichment of logs with podName, namespace, containerName, containerId
+* Joining long log lines over 4KB into one log line (log lines over 4KB are split into multiple lines)
+* Parsing containerd log headers (timestamp, stream, flags)
+* Parsing message content with Logagent's parser library
+
+
+## Forward all Container Logs
+
+Run Logagent as [Kubernetes DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset).
+
+First, create the [ibm-cloud-logagent-ds.yml](https://github.com/sematext/logagent-js/blob/master/kubernetes/ibm-cloud-logagent-ds.yml) DaemonSet file.
+
+```
+curl -o ibm-cloud-logagent-ds.yml  https://raw.githubusercontent.com/sematext/logagent-js/master/kubernetes/ibm-cloud-logagent-ds.yml
+```
+
+Set your `LOGS_TOKEN` in the `spec.env` section in the `ibm-cloud-logagent-ds.yml` file.
+
+Then run the DaemonSet:
+
+```
+kubectl create -f ibm-cloud-logagent-ds.yml
+```
+
+## Use `LOG_GLOB` to Filter Which Container Logs to Forward
+
+hu ha...
+
+## Drop noisy Container Logs 
+
+ha hu...
+
+## Forward Container Logs to Multiple Apps with Log Routing
+
+ha hu...
+
+## Enable Kubernetes Audit Logs
+
+hu ha...
+
+

--- a/docs/integration/ibm-cloud-kubernetes-logs.md
+++ b/docs/integration/ibm-cloud-kubernetes-logs.md
@@ -1,0 +1,8 @@
+title: IBM Cloud Kubernetes Logs Integration
+description: Sematext IBM Cloud Kubernetes Logs integration is configured by running Logagent as a Daemonset in your cluster.
+
+Sematext offers a Kubernetes Audit logs receiver endpoint. Everything you need to do is to configure the Kubernetes API Server to send logs to it.
+
+## Sematext Kubernetes Audit Logs Quick Start
+
+Kubernetes audit logs are detailed descriptions of each call made to the Kubernetes API Server. They provide a chronological sequence of activities that lead to the state of the system at a specific moment. They are extremely useful for security and compliance purposes, telling you exactly who did what, when, and how. You can configure Kubernetes Audit Logs by using any of the two options below.

--- a/docs/integration/ibm-cloud-kubernetes-logs.md
+++ b/docs/integration/ibm-cloud-kubernetes-logs.md
@@ -158,7 +158,9 @@ output:
 
 ```
 
-In the `filters.message.ex
+In the `filters` section you can pick a field to apply regex mathing to.
+If there's a match you can either include or exclude that particular log line.
+The sample above will include all log lines that match `critical|auth|error|failed` but exclude all that match `status`.
 
 ### Forward Container Logs to Multiple Apps with Log Routing
 

--- a/docs/integration/ibm-cloud-kubernetes-logs.md
+++ b/docs/integration/ibm-cloud-kubernetes-logs.md
@@ -15,18 +15,22 @@ The Logagent [input-filter for Containerd](../logagent/input-filter-containerd/)
 
 * Tailing log files from `/var/log/containers/`, `/var/log/pods` and `/var/data/kubeletlogs`
 * Enrichment of logs with podName, namespace, containerName, containerId
-* Joining long log lines over 4KB into one log line (log lines over 4KB are split into multiple lines)
+* Joining long log lines over 4KB into one log line
 * Parsing containerd log headers (timestamp, stream, flags)
 * Parsing message content with Logagent's parser library
 
 
-## Forward all Container Logs
+## Default Setup of IBM Cloud Kubernetes Logs
+
+With the default setup you edit env vars to change the configuration.
+
+### Forward all Container Logs
 
 Run Logagent as [Kubernetes DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset).
 
 First, create the [ibm-cloud-logagent-ds.yml](https://github.com/sematext/logagent-js/blob/master/kubernetes/ibm-cloud-logagent-ds.yml) DaemonSet file.
 
-```
+```bash
 curl -o ibm-cloud-logagent-ds.yml  https://raw.githubusercontent.com/sematext/logagent-js/master/kubernetes/ibm-cloud-logagent-ds.yml
 ```
 
@@ -38,19 +42,129 @@ Then run the DaemonSet:
 kubectl create -f ibm-cloud-logagent-ds.yml
 ```
 
-## Use `LOG_GLOB` to Filter Which Container Logs to Forward
+### Use `LOG_GLOB` to Filter Which Container Logs to Forward
 
-hu ha...
+Log globs make it easy to use wildcards to filter in/out which log files to tail.
+In the `spec.env.LOG_GLOB` env var you can set values to not include logs from certain containers.
+To read more about log globs, [check this out](https://www.npmjs.com/package/glob).
 
-## Drop noisy Container Logs 
+Here's how you can exclude all logs from the `kube-system` namespace:
+```yaml
+env:
+  - name: LOG_GLOB
+    value: "/var/log/containers/!(*kube-system*.log);/var/log/*.log"
+```
+
+Or, only include logs from the `default` namespace:
+```yaml
+env:
+  - name: LOG_GLOB
+    value: "/var/log/containers/*default*.log);/var/log/*.log"
+```
+
+This is a quick way of including/excluding logs from containers.
+
+## Advanced Setup of IBM Cloud Kubernetes Logs
+
+With the advanced setup you add a `logagent.conf` file as a `ConfigMap` to change the configuration.
+With this config file you have more control over the settings, including:
+
+- dropping logs
+- log routing
+- more fine tuned filtering
+- ability to add audit logs
+
+### 1. Create a `logagent.conf` file
+
+The logagent.conf is the main config file for Logagent.
+
+```yaml
+# logagent.conf
+options:
+  debug: false
+
+input: 
+  files: 
+    - /var/log/*.log
+    - /var/log/containers/*.log
+
+inputFilter:
+  - module: input-filter-k8s-containerd
+
+output:
+  elasticsearch:
+    module: elasticsearch
+    url: https://logsene-receiver.sematext.com
+    index: YOUR_SEMATEXT_LOGS_TOKEN
+```
+
+This particular config above will work the same as using the default setup with env vars.
+
+### 2. Add the `logagent.conf` as a `ConfigMap`
+
+Create the ConfigMap from the `logagent.conf` file. Run this command from the dir where you have the `logagent.conf`:
+
+```bash
+kubectl create configmap logagent-config --from-file=./logagent.conf
+```
+
+### 3. Create the Logagent DaemonSet
+
+Create the [ibm-cloud-logagent-with-config-ds.yml](https://github.com/sematext/logagent-js/blob/master/kubernetes/ibm-cloud-logagent-with-config-ds.yml) DaemonSet file.
+
+```bash
+curl -o ibm-cloud-logagent-with-config-ds.yml https://raw.githubusercontent.com/sematext/logagent-js/master/kubernetes/ibm-cloud-logagent-with-config-ds.yml 
+```
+
+You don't need to change anything as all the config is in `logagent.conf`, just run the DaemonSet:
+
+```bash
+kubectl create -f ibm-cloud-logagent-with-config-ds.yml
+```
+
+When you want to edit the config, change the `logagent.conf`, recreate the ConfigMap, restart the Logagent pod to grab the new ConfigMap and you're done!
+Continue reading below to see how to configure more advanced settings.
+
+### Drop noisy Container Logs 
+
+Edit the `logagent.conf` to add the [drop-events](../logagent/output-filter-dropevents/) outputFilter.
+
+```yaml
+# Global options
+options:
+  debug: false
+
+input: 
+  files: 
+    - /var/log/*.log
+    - /var/log/containers/*.log
+
+inputFilter:
+  - module: input-filter-k8s-containerd
+
+outputFilter:
+  dropEvents:
+    module: drop-events
+    filters:
+      message:
+        include: !!js/regexp /critical|auth|error|failed/
+        exclude: !!js/regexp /status/i
+
+output:
+  elasticsearch:
+    module: elasticsearch
+    url: https://logsene-receiver.sematext.com
+    index: YOUR_SEMATEXT_LOGS_TOKEN
+
+```
+
+In the `filters.message.ex
+
+### Forward Container Logs to Multiple Apps with Log Routing
 
 ha hu...
 
-## Forward Container Logs to Multiple Apps with Log Routing
-
-ha hu...
-
-## Enable Kubernetes Audit Logs
+### Enable Kubernetes Audit Logs
 
 hu ha...
 

--- a/docs/integration/ibm-cloud-kubernetes-logs.md
+++ b/docs/integration/ibm-cloud-kubernetes-logs.md
@@ -164,7 +164,40 @@ The sample above will include all log lines that match `critical|auth|error|fail
 
 ### Forward Container Logs to Multiple Apps with Log Routing
 
-ha hu...
+To enable log routing you edit the output plugin to use multiple indices.
+Under the token value you need to add a regex for the log file you want to match.
+
+```yaml
+# Global options
+options:
+  debug: true
+
+input: 
+  files: 
+    - /var/log/*.log
+    - /var/log/containers/*.log
+
+inputFilter:
+  - module: input-filter-k8s-containerd
+
+outputFilter:
+  dropEventsFilter:
+    module: drop-events
+    filters:
+      message:
+        exclude: !!js/regexp /status/i
+
+output:
+  elasticsearch:
+    module: elasticsearch
+    url: https://logsene-receiver.sematext.com
+    indices: 
+      b0e9f481-xxxx-xxxx-xxxx-3ff20227d3d3: # All logs except kube-system
+        - ^(?!.*(kube-system).*).*\.log
+      9365eb2f-xxxx-xxxx-xxxx-5a833072353f: # Only kube-system logs
+        - .*kube-system.*\.log
+
+```
 
 ### Enable Kubernetes Audit Logs
 

--- a/docs/logagent/input-filter-containerd.md
+++ b/docs/logagent/input-filter-containerd.md
@@ -3,7 +3,7 @@ description: Logagent features modular logging architecture framework where each
 
 ## Input Filter: Kubernetes cri-o / containerd  
 
-Parsing cri-o containerd log format. Use the file input plugin to read log files. 
+Parsing cri-o containerd log format. Use the file input plugin to read log files. See the [IBM Cloud Kuberentes Logs integration](../integration/ibm-cloud-kubernetes-logs/) for a more detailed explanation.
 
 ## Configuration 
 

--- a/docs/logagent/output-filter-dropevents.md
+++ b/docs/logagent/output-filter-dropevents.md
@@ -37,7 +37,7 @@ outputFilter:
       message: 
         # don't drop logs with 
         # messages containing the words critical,error,auth or failed 
-        include: !js/regexp /critical|auth|error|failed/
+        include: !!js/regexp /critical|auth|error|failed/
 
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ pages:
         - Journald: integration/journald-integration.md
         - Vercel: integration/vercel-logs-integration.md
         - Mobile Apps Logs: integration/mobile-apps-logs.md
+        - IBM Cloud Kubernetes Logs: integration/ibm-cloud-kubernetes-logs.md
       - Notification Hooks:
         - Custom Alert Webhooks: integration/alerts-webhooks-integration.md
         - Big Panda: integration/alerts-bigpanda-integration.md


### PR DESCRIPTION
Added a page explaining how to set up Kubernetes logging for the IBM Cloud Kubernetes Service that runs on the Containerd runtime.

![localhost_8000_integration_ibm-cloud-kubernetes-logs_](https://user-images.githubusercontent.com/15029531/87040713-6987ad80-c1f1-11ea-90fb-3d5456b11c7f.png)
