### PR TITLE
SC-9558 - Add Browser SDK section to Experience

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ pages:
       - Element Timing: experience/element-timing.md
       - Web Vitals: experience/webvitals.md
       - Integrations: experience/integrations.md
+      - Browser SDK: agents/browser.md
       - Changelog: experience/changelog.md
       - FAQ: experience/faq.md
     - Synthetics:


### PR DESCRIPTION
Hi, 

A quick addition, the link to `Browser SDK` in the `Experience` section of the docs. I think we don't need additional description we can just open the page from `Agents` section that we already have. It looks like this:

![Screenshot 2020-09-25 at 12 25](https://user-images.githubusercontent.com/839333/94257869-40430780-ff2c-11ea-97f1-5609ca5fd5d4.png)