### PR TITLE
Adjust docs to reflect new tags changes re transactions

### DIFF
--- a/docs/agents/browser.md
+++ b/docs/agents/browser.md
@@ -31,7 +31,7 @@ The following commands are currently supported by the RUM script:
  - `config` - Configures the script. It requires the `token` and `receiverUrl` configuration parameters. You can also provide the `ignoreBotData` Boolean parameter to ignore metrics coming from bots.
  - `identify` - Identifies the user. Requires the `name` and the `identifier` keys to be present, which are used to identify a user.  
  - `routeChange` - Informs the metrics gathering script about a route change. It accepts a single parameter that should take the value of the new route. 
- - `startTransaction` - Informs the metrics gathering script about transaction start. It accepts a single parameter that should take the value of the transaction name.
+ - `startTransaction` - Informs the metrics gathering script about transaction start. It accepts two parameters. The first is the transaction name. The second parameter is optional custom tags.
  - `endTransaction` - Informs the metrics gathering script about transaction end. It accepts a single parameter that should take the value of the name of the transaction that we want to end.
  - `pageLoad` - Provides metrics related to page load.
  - `ajax` - Provides metrics related to HTTP requests.

--- a/docs/experience/on-page-transaction.md
+++ b/docs/experience/on-page-transaction.md
@@ -38,7 +38,7 @@ Add this function call to start the transaction. The second parameter must match
  strum('startTransaction', 'ExampleTransaction');
 ```
 
-And by this call transaction will be ended.
+When whatever you are measuring is finished, call `endTransaction` to finish the transaction.
 
 ```javascript
  strum('endTransaction', 'ExampleTransaction');
@@ -53,4 +53,17 @@ Finally, this is what you will see after the transactions start sending data to 
   title="Transactions in action"
 />
 
-That's everything you need to configure. Enjoy your Transactions!
+## Custom Tags
+
+You can attach custom tags to transactions by providing them as another argument when calling `startTransaction`:
+
+```javascript
+ strum('startTransaction', 'ExampleTransaction', { someTag: 'value' });
+```
+
+This tag will be applied to this single event only. If you wish to apply custom tags to all events, then please check out [Tags](/experience/tags).
+
+
+That's everything you need to use On-Page Transaction. Enjoy!
+
+


### PR DESCRIPTION
This PR adjusts the Experience docs to reflect that we can now override custom tags for single transaction.