### PR TITLE
Docs for Logs templates and mappings

### DIFF
--- a/docs/logs/field-types.md
+++ b/docs/logs/field-types.md
@@ -138,3 +138,6 @@ In Sematext Logs it will be enriched and look like this:
 If you want to use this field type you can send events with a field name and
 data in a format presented above. Alternatively, you can use Field
 Editor to manually create a field of the geo-point type.
+
+If you want to adjust the structure of your data you can use the Field Editor 
+functionality in your Logs App settings or use the [Templates and Mappings](/logs/mappings-templates) functionality.

--- a/docs/logs/fields.md
+++ b/docs/logs/fields.md
@@ -1,22 +1,12 @@
 title: Fields
 description: Sematext's Logs management App looks for special fields in logs, namely host, source, facility, severity, syslog-tag, tags, message, and @timestamp
 
-Tags from the [Common Schema](../tags/common-schema) apply to Sematext Logs as well. Additionally, there are Logs-specific fields which also get special treatment:
-
-  - host
-  - source
-  - facility
-  - severity
-  - syslog-tag
-  - tags
-  - message
-  - @timestamp
-
-To read more, check out our [Common Schema for Logs Tags](../tags/common-schema/#logs-tags).
-
-<img alt="Sematext Logs Special Fields" src="../../images/logs/logsene-special-fields.gif" title="Sematext Logs Special Fields">
-
-**Note:**
+Every log event that you ship to Sematext Logs has its structure - it is divided into fields. Each field can have a [type](/logs/field-types/), for example [string](/logs/field-types/#string), [date](/logs/field-types/#date), or [integer](/logs/field-types/#integerlong). It can even be an object holding structured data. We do everything we can to ensure that your log event field types are inferred correctly. However, you may also want to set field types explicitly. 
 
 If you want to adjust the structure of your data you can use the Field Editor 
 functionality in your Logs App settings or use the [Templates and Mappings](/logs/mappings-templates) functionality.
+
+---
+**Note:**
+Tags from the [Common Schema](../tags/common-schema) apply to Sematext Logs as well. Additionally, there are Logs-specific fields which also get special treatment to learn more, check out our [Common Schema for Logs Tags](../tags/common-schema/#logs-tags).
+---

--- a/docs/logs/fields.md
+++ b/docs/logs/fields.md
@@ -15,3 +15,8 @@ Tags from the [Common Schema](../tags/common-schema) apply to Sematext Logs as w
 To read more, check out our [Common Schema for Logs Tags](../tags/common-schema/#logs-tags).
 
 <img alt="Sematext Logs Special Fields" src="../../images/logs/logsene-special-fields.gif" title="Sematext Logs Special Fields">
+
+**Note:**
+
+If you want to adjust the structure of your data you can use the Field Editor 
+functionality in your Logs App settings or use the [Templates and Mappings](/logs/mappings-templates) functionality.

--- a/docs/logs/index-events-via-elasticsearch-api.md
+++ b/docs/logs/index-events-via-elasticsearch-api.md
@@ -72,7 +72,7 @@ curl -XPOST https://logsene-receiver.sematext.com/_bulk --data-binary @req; echo
 ## Default Log Index Mapping
 
 A [mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/glossary.html#mapping)
-is a way to define how your logs are indexed - which fields are in each log event and how each field is indexed. There is no "default" index mapping.  Sematext automatically creates the mapping in each Logs App when your first ship your logs.  Each App can have its own mapping and it can be changed at any time from within Sematext.  There are some [special fields](special-fields) though.
+is a way to define how your logs are indexed - which fields are in each log event and how each field is indexed. Each Logs App comes with a default mappings definition which includes pre-defined [fields](/logs/fields/). In addition to that Sematext automatically creates the mapping in each Logs App when you first ship your logs. Each App can have its own mapping and it can be changed at any time from within Sematext using the fields editor or by using the [mappings and templates](/logs/mappings-templates) functionality. There are some [special fields](special-fields) though.
 
   - the **@timestamp** field is an
     [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) date.  See [Supported Date Formats](supported-date-formats).
@@ -88,7 +88,7 @@ is a way to define how your logs are indexed - which fields are in each log even
 ## Custom Log Index Mapping
 
 If the default log index fields (also known as index mapping) don't fit
-your needs you can create completely custom index mapping. See [Custom Logsene Mapping Template How-To](https://sematext.com/blog/custom-elasticsearch-index-templates-in-logsene/).
+your needs you can create completely custom index mapping. See [Mappings and Templates](/logs/mappings-templates) section.
 
 Note that if you have N different log structures, the best way to
 handle that is by creating N Logs Apps, each with its own index

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -1,0 +1,53 @@
+title: Mappings and Templates
+description: Field mappings and indices templates supported by Sematext Cloud based SaaS / On-premises logging as a service platform
+
+Every log event that you ship to Sematext Logs has its structure - it is divided into fields. Each field can have a [type](/logs/field-types/), for example [String](/logs/field-types/#string), [Date](/logs/field-types/#date), or [Integer](/logs/field-types/#floatdouble). It can even be an object holding structured data. We do everything we can to ensure that the fields of your logs have the correct types. However, there are situations where you know better what kind of fields you need and which types of data you want to use. 
+
+In such cases, Sematext Logs provide mechanism for handling the data structure - the templates and the mappings. The mentioned functionality comes from Elasticsearch and its compatible with its API, however, because of the nature of the Sematext platform it works differently.
+
+## The Templates
+The templates mechanism works by providing guidance for Elasticsearch on the structure of the data. Every time an index is created all the defined templates are used to pre-create the fields with their types in such index. It is no different in Sematext Logs. By defining a template you provide information on what fields and types you expect in your data. 
+
+You can easily create a new template by running the following request:
+
+``` code
+curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_template_name' -d '{
+ "order": 31,
+ "mappings": {
+   "properties": {
+     "host_name": {
+       "type": "keyword"
+     }
+   }
+ }
+}'
+```
+
+You need to provide your [write token](/logs/settings/) in the URI of the request and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes. 
+
+Once you successfully create a new template your index will be rolled over. That means that an internal mechanism will create a new index and will apply the new template for you. 
+
+## The Mappings
+The mappings mechanism in Elasticsearch works by providing the data structure during index creation or by updating the data structure for an already created index. It wouldn't work well in the case of the Sematext Logs platform, because we try to provide you with the best indexing and searching experience possible, and thus we continuously create new indices in the background. 
+
+Because of that, the mappings functionality in Sematext Logs works differently. When you send the mappings request it is translated into a template creation request. 
+
+For example this command results in a mappings request made to Sematext Cloud:
+
+``` code
+curl -H 'Authorization: apiKey YOUR_API_KEY' -XPUT 'https://logsene-receiver.sematext.com/YOUR_WRITE_TOKEN/_mapping' -d '{
+  "mappings": {
+    "_doc": {
+      "properties": {
+        "email_write": {
+          "type": "keyword"
+        }
+      }
+    }
+  } 
+}'
+```
+
+You can find your [API key](/api) in the Settings section of Sematext platform and your Logs write token can be found in the token section of your Logs App. 
+
+In the background, the mappings definition will be changed into a new template. Sematext Logs does that to ensure that your mapping will be moved when we create a new, internal index for your Logs App. 

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -86,7 +86,7 @@ The mappings API support is provided by Sematext Logs for compatibility purposes
 For example this command results in a mappings request made to Sematext Cloud:
 
 ``` code
-curl -H 'Authorization: apiKey YOUR_API_KEY' -XPUT 'https://logsene-receiver.sematext.com/LOGS_TOKEN/_mapping' -d '{
+curl -XPUT 'https://logsene-receiver.sematext.com/LOGS_TOKEN/_mapping' -d '{
   "mappings": {
     "_doc": {
       "properties": {
@@ -98,7 +98,5 @@ curl -H 'Authorization: apiKey YOUR_API_KEY' -XPUT 'https://logsene-receiver.sem
   } 
 }'
 ```
-
-You can find your [API key](/api) in your [Account settings](https://apps.sematext.com/ui/account/api) ([EU](https://apps.eu.sematext.com/ui/account/api)) and your `LOGS_TOKEN` in each Logs App's Settings.
 
 In the background, the mappings definition will be changed into a new template to ensure that the changes are persisted in your Sematext Logs App.

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -1,12 +1,12 @@
 title: Mappings and Templates
-description: Field mappings and indices templates supported by Sematext Cloud based SaaS / On-premises logging as a service platform
+description: Field mappings and index template supported by Sematext Cloud
 
-Every log event that you ship to Sematext Logs has its structure - it is divided into fields. Each field can have a [type](/logs/field-types/), for example [String](/logs/field-types/#string), [Date](/logs/field-types/#date), or [Integer](/logs/field-types/#floatdouble). It can even be an object holding structured data. We do everything we can to ensure that the fields of your logs have the correct types. However, there are situations where you know better what kind of fields you need and which types of data you want to use. 
+Every log event that you ship to Sematext Logs has its structure - it is divided into fields. Each field can have a [type](/logs/field-types/), for example [String](/logs/field-types/#string), [Date](/logs/field-types/#date), or [Integer](/logs/field-types/#floatdouble). It can even be an object holding structured data. We do everything we can to ensure that your log event field types are inferred correctly. However, you may also want to set field types explicitly. 
 
-In such cases, Sematext Logs provide mechanism for handling the data structure - the templates and the mappings. The mentioned functionality comes from Elasticsearch and its compatible with its API, however, because of the nature of the Sematext platform it works differently.
+To do that you can create templates and configure mapping via Sematext's [Elasticsearch-compatible API](/logs/index-events-via-elasticsearch-api/) as shown below.
 
 ## The Templates
-The templates mechanism works by providing guidance for Elasticsearch on the structure of the data. Every time an index is created all the defined templates are used to pre-create the fields with their types in such index. It is no different in Sematext Logs. By defining a template you provide information on what fields and types you expect in your data. 
+Logs are stored in an index in Sematext. Each Logs App has its own index and its own, independent log event structure. A template provides information about the structure - fields and their types - of log events in a given App and its underlying index. Every time an index is created all the defined templates are used to pre-create the fields with their types in such index. It is no different in Sematext Logs. By defining a template you provide information on what fields and types you expect in your data. 
 
 You can easily create a new template by running the following request:
 
@@ -23,7 +23,7 @@ curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_tem
 }'
 ```
 
-You need to provide your [write token](/logs/settings/) in the URI of the request and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes. 
+You need to provide your [write token](/logs/settings/) in the URI of the request and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes and result in 
 
 Once you successfully create a new template your index will be rolled over. That means that an internal mechanism will create a new index and will apply the new template for you. 
 

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -1,7 +1,7 @@
 title: Mappings and Templates
 description: Field mappings and index template supported by Sematext Cloud
 
-Every log event that you ship to Sematext Logs has its structure - it is divided into fields. Each field can have a [type](/logs/field-types/), for example [String](/logs/field-types/#string), [Date](/logs/field-types/#date), or [Integer](/logs/field-types/#floatdouble). It can even be an object holding structured data. We do everything we can to ensure that your log event field types are inferred correctly. However, you may also want to set field types explicitly. 
+Every log event that you ship to Sematext Logs has its structure - it is divided into fields. Each field can have a [type](/logs/field-types/), for example [string](/logs/field-types/#string), [date](/logs/field-types/#date), or [integer](/logs/field-types/#integerlong). It can even be an object holding structured data. We do everything we can to ensure that your log event field types are inferred correctly. However, you may also want to set field types explicitly. 
 
 To do that you can create templates and configure mapping via Sematext's [Elasticsearch-compatible API](/logs/index-events-via-elasticsearch-api/) as shown below.
 
@@ -28,7 +28,45 @@ curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_tem
 For EU location use **logsene-receiver.eu.sematext.com** instead of **logsene-receiver.sematext.com**.
 ---
 
-You need to provide your [write token](/logs/settings/) in the URI of the request and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes and result in error when being used.
+You need to provide your [write token](/logs/settings/) in the URI of the request, the **order**, and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes and result in error when being used.
+
+### Template Structure
+The main section of each template definition is the **mappings** section which contains information about the fields and their types. Your templates may include one or more fields fields that are not considered special (more information in the [fields](/logs/fields)). For example:
+
+``` code
+curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_mytemplate' -d '{
+ "order": 40,
+ "mappings": {
+   "properties": {
+     "user_name": {
+       "type": "keyword"
+     },
+     "user_score": {
+       "type": "integer"
+     },
+     "user_active": {
+       "type": "boolean"
+     },
+     "user_description": {
+       "type": "text"
+     }
+   }
+ }
+}'
+```
+
+The above template contains the **mappings** object. Inside it we fine the **properties** object which is responsible for defining the fields and their types. Each field is a JSON object that contains a name, like **user_name** in the above example and the type defined by using the **type** keyword. 
+
+The field types that can be used in Sematext Logs App are as follows ([learn more about the field types](/logs/field-types)):
+
+ * keyword (non-analyzed string)
+ * text (analyzed string)
+ * boolean
+ * integer
+ * long
+ * double
+ * float
+ * object
 
 Once you successfully create a new template your index will be rolled over. That means that an internal mechanism will create a new index and will apply the new template for you. 
 

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -1,9 +1,7 @@
 title: Mappings and Templates
 description: Field mappings and index template supported by Sematext Cloud
 
-Every log event that you ship to Sematext Logs has its structure - it is divided into fields. Each field can have a [type](/logs/field-types/), for example [string](/logs/field-types/#string), [date](/logs/field-types/#date), or [integer](/logs/field-types/#integerlong). It can even be an object holding structured data. We do everything we can to ensure that your log event field types are inferred correctly. However, you may also want to set field types explicitly. 
-
-To do that you can create templates and configure mapping via Sematext's [Elasticsearch-compatible API](/logs/index-events-via-elasticsearch-api/) as shown below.
+To adjust structure of your data in Sematext Logs you can create templates and configure mapping via Sematext's [Elasticsearch-compatible API](/logs/index-events-via-elasticsearch-api/) as shown below.
 
 ## Index Templates
 Logs are stored in an index in Sematext. Each Logs App has its own index and its own, independent log event structure. A template provides information about the structure - fields and their types - of log events in a given App and its underlying index. Every time an index is created all the defined templates are used to pre-create the fields with their types in such index. It is no different in Sematext Logs. By defining a template you provide information on what fields and types you expect in your data. 

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -23,6 +23,8 @@ curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_tem
 }'
 ```
 
+**Note** For EU location use **logsene-receiver.eu.sematext.com** instead of **logsene-receiver.sematext.com**.
+
 You need to provide your [write token](/logs/settings/) in the URI of the request and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes and result in error when being used.
 
 Once you successfully create a new template your index will be rolled over. That means that an internal mechanism will create a new index and will apply the new template for you. 

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -5,7 +5,7 @@ Every log event that you ship to Sematext Logs has its structure - it is divided
 
 To do that you can create templates and configure mapping via Sematext's [Elasticsearch-compatible API](/logs/index-events-via-elasticsearch-api/) as shown below.
 
-## The Templates
+## Index Templates
 Logs are stored in an index in Sematext. Each Logs App has its own index and its own, independent log event structure. A template provides information about the structure - fields and their types - of log events in a given App and its underlying index. Every time an index is created all the defined templates are used to pre-create the fields with their types in such index. It is no different in Sematext Logs. By defining a template you provide information on what fields and types you expect in your data. 
 
 You can easily create a new template by running the following request:
@@ -75,7 +75,7 @@ Before adding new fields to your templates ensure that they are not present in t
 
 Once you successfully create a new template your index will be rolled over. That means that an internal mechanism will create a new index and will apply the new template for you. 
 
-## The Mappings
+## Index Mappings
 In addition to the templates mechanism Sematext Logs supports mappings, mostly for compatibility purposes. The mappings mechanism in Elasticsearch works by providing the data structure during index creation or by updating the data structure for an already created index. That wouldn't work in case of Sematext Logs App. When you send the mappings request it is translated into a template creation request. 
 
 ---

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -32,7 +32,7 @@ Once you successfully create a new template your index will be rolled over. That
 ## The Mappings
 The mappings mechanism in Elasticsearch works by providing the data structure during index creation or by updating the data structure for an already created index. It wouldn't work well in the case of the Sematext Logs platform, because we try to provide you with the best indexing and searching experience possible, and thus we continuously create new indices in the background. 
 
-Because of that, the mappings functionality in Sematext Logs works differently. When you send the mappings request it is translated into a template creation request. 
+Because of that, the mappings functionality in Sematext Logs works differently. When you send the mappings request it is translated into a template creation request. Note that the mappings API support is provided by Sematext Logs for compatibility purposes and when changing the structure of your data you should use the [templates](/logs/mappings-templates/#the-templates) functionality.
 
 For example this command results in a mappings request made to Sematext Cloud:
 

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -11,7 +11,7 @@ Logs are stored in an index in Sematext. Each Logs App has its own index and its
 You can easily create a new template by running the following request:
 
 ``` code
-curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_template_name' -d '{
+curl -XPUT 'https://logsene-receiver.sematext.com/_template/LOGS_TOKEN_template_name' -d '{
  "order": 31,
  "mappings": {
    "properties": {
@@ -28,13 +28,13 @@ curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_tem
 For EU location use **logsene-receiver.eu.sematext.com** instead of **logsene-receiver.sematext.com**.
 ---
 
-You need to provide your [write token](/logs/settings/) in the URI of the request, the **order**, and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes and result in error when being used.
+You need to provide your [`LOGS_TOKEN`](/logs/settings/) in the URI of the request, the **order**, and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes and result in error when being used.
 
 ### Template Structure
-The main section of each template definition is the **mappings** section which contains information about the fields and their types. Your templates may include one or more fields fields that are not considered special (more information in the [fields](/logs/fields)). For example:
+The main section of each template definition is the **mappings** section which contains information about the fields and their types. Your templates may include one or more fields that are not considered special. More information about this in the [fields section](/logs/fields)). For example:
 
 ``` code
-curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_mytemplate' -d '{
+curl -XPUT 'https://logsene-receiver.sematext.com/_template/LOGS_TOKEN_mytemplate' -d '{
  "order": 40,
  "mappings": {
    "properties": {
@@ -55,7 +55,7 @@ curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_myt
 }'
 ```
 
-The above template contains the **mappings** object. Inside it we fine the **properties** object which is responsible for defining the fields and their types. Each field is a JSON object that contains a name, like **user_name** in the above example and the type defined by using the **type** keyword. 
+The template above contains the **mappings** object. Inside it we find the **properties** object which is responsible for defining the fields and their types. Each field is a JSON object that contains a name, like **user_name**. The example above we see the type defined by using the **type** keyword.
 
 The field types that can be used in Sematext Logs App are as follows ([learn more about the field types](/logs/field-types)):
 
@@ -86,7 +86,7 @@ The mappings API support is provided by Sematext Logs for compatibility purposes
 For example this command results in a mappings request made to Sematext Cloud:
 
 ``` code
-curl -H 'Authorization: apiKey YOUR_API_KEY' -XPUT 'https://logsene-receiver.sematext.com/YOUR_WRITE_TOKEN/_mapping' -d '{
+curl -H 'Authorization: apiKey YOUR_API_KEY' -XPUT 'https://logsene-receiver.sematext.com/LOGS_TOKEN/_mapping' -d '{
   "mappings": {
     "_doc": {
       "properties": {
@@ -99,6 +99,6 @@ curl -H 'Authorization: apiKey YOUR_API_KEY' -XPUT 'https://logsene-receiver.sem
 }'
 ```
 
-You can find your [API key](/api) in your [Account settings](https://apps.sematext.com/ui/account/api) ([EU](https://apps.eu.sematext.com/ui/account/api)) and your Logs write token in each Logs App's Settings.
+You can find your [API key](/api) in your [Account settings](https://apps.sematext.com/ui/account/api) ([EU](https://apps.eu.sematext.com/ui/account/api)) and your `LOGS_TOKEN` in each Logs App's Settings.
 
 In the background, the mappings definition will be changed into a new template to ensure that the changes are persisted in your Sematext Logs App.

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -48,6 +48,6 @@ curl -H 'Authorization: apiKey YOUR_API_KEY' -XPUT 'https://logsene-receiver.sem
 }'
 ```
 
-You can find your [API key](/api) in the Settings section of Sematext platform and your Logs write token can be found in the token section of your Logs App. 
+You can find your [API key](/api) in your [Account settings](https://apps.sematext.com/ui/account/api) ([EU](https://apps.eu.sematext.com/ui/account/api)) and your Logs write token in each Logs App's Settings.
 
-In the background, the mappings definition will be changed into a new template. Sematext Logs does that to ensure that your mapping will be moved when we create a new, internal index for your Logs App. 
+In the background, the mappings definition will be changed into a new template to ensure that the changes are persisted in your Sematext Logs App.

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -15,7 +15,7 @@ curl -XPUT 'https://logsene-receiver.sematext.com/_template/LOGS_TOKEN_template_
  "order": 31,
  "mappings": {
    "properties": {
-     "host_name": {
+     "user_name": {
        "type": "keyword"
      }
    }

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -23,16 +23,22 @@ curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_tem
 }'
 ```
 
-**Note** For EU location use **logsene-receiver.eu.sematext.com** instead of **logsene-receiver.sematext.com**.
+---
+**Note:**
+For EU location use **logsene-receiver.eu.sematext.com** instead of **logsene-receiver.sematext.com**.
+---
 
 You need to provide your [write token](/logs/settings/) in the URI of the request and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes and result in error when being used.
 
 Once you successfully create a new template your index will be rolled over. That means that an internal mechanism will create a new index and will apply the new template for you. 
 
 ## The Mappings
-The mappings mechanism in Elasticsearch works by providing the data structure during index creation or by updating the data structure for an already created index. It wouldn't work well in the case of the Sematext Logs platform, because we try to provide you with the best indexing and searching experience possible, and thus we continuously create new indices in the background. 
+In addition to the templates mechanism Sematext Logs supports mappings, mostly for compatibility purposes. The mappings mechanism in Elasticsearch works by providing the data structure during index creation or by updating the data structure for an already created index. That wouldn't work in case of Sematext Logs App. When you send the mappings request it is translated into a template creation request. 
 
-Because of that, the mappings functionality in Sematext Logs works differently. When you send the mappings request it is translated into a template creation request. Note that the mappings API support is provided by Sematext Logs for compatibility purposes and when changing the structure of your data you should use the [templates](/logs/mappings-templates/#the-templates) functionality.
+---
+**NOTE:**
+The mappings API support is provided by Sematext Logs for compatibility purposes and when changing the structure of your data you should use the [templates](/logs/mappings-templates/#the-templates) functionality.
+---
 
 For example this command results in a mappings request made to Sematext Cloud:
 

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -68,6 +68,11 @@ The field types that can be used in Sematext Logs App are as follows ([learn mor
  * float
  * object
 
+---
+**NOTE:**
+Before adding new fields to your templates ensure that they are not present in the [special fields](/logs/fields) or in the [common schema](/tags/common-schema/).
+---
+
 Once you successfully create a new template your index will be rolled over. That means that an internal mechanism will create a new index and will apply the new template for you. 
 
 ## The Mappings

--- a/docs/logs/mappings-templates.md
+++ b/docs/logs/mappings-templates.md
@@ -23,7 +23,7 @@ curl -XPUT 'https://logsene-receiver.sematext.com/_template/YOUR_WRITE_TOKEN_tem
 }'
 ```
 
-You need to provide your [write token](/logs/settings/) in the URI of the request and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes and result in 
+You need to provide your [write token](/logs/settings/) in the URI of the request and the mappings definition. The **order** property needs to be higher than **20**. The ones below that value are reserved for internal Sematext platform purposes and result in error when being used.
 
 Once you successfully create a new template your index will be rolled over. That means that an internal mechanism will create a new index and will apply the new template for you. 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ pages:
       - Fields: logs/fields.md
       - Field Types: logs/field-types.md
       - Supported Date Formats: logs/supported-date-formats.md
+      - Mappings and Templates: logs/mappings-templates.md
       - Archiving: logs/archiving.md
       - Discovery:
         - Overview: logs/discovery/intro.md


### PR DESCRIPTION
Hi guys, 

This PR introduces templates and mappings dedicated section to Logs docs. It shows how to use templates and what it means to use mappings. I have another docs JIRA on me regarding the fields editor, which will bring some additional information on data structure and SC Logs. I think that when it comes to templates this is enough. 

The page looks as follows:

![templates](https://user-images.githubusercontent.com/839333/103008868-0f2ba080-4536-11eb-9ed7-f8292399b7f1.png)
