### PR TITLE
Add entry for User-Agent information

### DIFF
--- a/docs/synthetics/faq.md
+++ b/docs/synthetics/faq.md
@@ -50,6 +50,9 @@ The default timeouts for the HTTP and Browser monitors are documented in their r
 
 Currently, it is not possible to change the default settings, except for the default navigation timeout in the Browser monitor scripts. It can be changed using the [page.setDefaultNavigationTimeout(timeout)](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagesetdefaultnavigationtimeouttimeout) API.
 
+### How can I filter requests from HTTP & Browser monitors?
+Both HTTP and Browser monitor requests will have the string "SematextSyntheticsRobot" in the User-Agent header. If your analytics software doesn't already filter out requests from Synthetics, you can use the User-Agent header to filter requests from Synthetics.
+
 
 ### Where can I find user journey scripts that I can customize for my own needs?
 You can find Browser monitor scripts for common use cases by selecting the Browse Examples link in the Create Monitor page. You can directly import a script from the example and change it to suit your needs. You can also find more examples [here](https://github.com/transitive-bullshit/awesome-puppeteer#examples).


### PR DESCRIPTION
This PR adds an entry to FAQ on filtering requests from Synthetics monitors based on User-Agent header.