### PR TITLE
SC-10932 info for SELinux users in relation to sematext-agent rpm/deb

### DIFF
--- a/docs/agents/sematext-agent/installation.md
+++ b/docs/agents/sematext-agent/installation.md
@@ -70,6 +70,10 @@ sudo zypper in sematext-agent
  </div>
 </div>
 
+
+Note: if you have SELinux enabled, see [How can I get the Agent running when SELinux is enabled](/monitoring/spm-faq/#how-do-i-get-the-agent-running-when-selinux-is-enabled).
+
+
 After the install completes, set your Infra App token by running the command below:
 
 ```


### PR DESCRIPTION
Info for SELinux users

SELinux is preventing sematext-agent processes from running in some cases. This PR adds the docs for SELinux users. Separately, I'll adjust rpm/deb installers to check whether it is enabled and print a link to FAQ entry if it is.