### PR TITLE
Update installation-windows.md

### DIFF
--- a/docs/logagent/installation-windows.md
+++ b/docs/logagent/installation-windows.md
@@ -16,7 +16,7 @@ setx PATH "%PATH%;%ProgramData%\npm" /M
 call npm i -g @sematext/logagent
 call npm i -g logagent-input-elasticsearch-stats
 call npm i -g logagent-input-windows-events
-call npm i -g node-windows
+call npm i -g node-windows@1.0.0-beta.6
 # run logagent windows version
 logagent-windows --help
 ```


### PR DESCRIPTION
Dependency typo in the latest node-windows module 1.0.0-beta.7 causing logagent to fail, updated the installation instructions to force the previous version node-windows 1.0.0-beta.6 without the typo.