### PR TITLE
Events fields and tags added to common schema

### DIFF
--- a/docs/tags/common-schema.md
+++ b/docs/tags/common-schema.md
@@ -183,3 +183,78 @@ Below are tags that are reserved for future use:
 | service.type | Service type e.g. `hadoop` |
 | span.id | Building block of a trace in distributed tracing |
 | trace.id | Building block of a trace in distributed tracing |
+
+## Events Tags
+
+### Fields
+
+When you create an event you can send a ```JSON``` document which consists of multiple
+fields. Each field can contain event main information or metadata. Even though there is
+no strict format of such a ```JSON``` document we recommend to some of fields. An event
+can contain the following set of fields, most of which are optional:
+
+Field Name | Field Type | Required | Notes 
+-----------|------------|----------|-------
+```timestamp``` | date       | no       | Time when event happened (if not specified,current time will be assumed). The format is [dateOptionalTime](https://joda-time.sourceforge.netapi-release/org/joda/time/format/ISODateTimeFormat.html#dateOptionalTimeParser) e.g.: ```2014-02-17T21:37:04+0100``` or```  2014-02-17T14:15:01.534471+02:00```.
+```os.host``` | string       | no       | Name of the host where the event has occurred.
+```type``` | string | yes | Event type which could be e.g. ```alert```, ```deployment```, etc. Events are later grouped in timeline based on event type which significantly improves visibility.
+```message``` | string       | yes       | Short description of event, e.g. ```Elasticsearch node03 onhost somehost06 restarted```. This is a default search field in Sematext UI, so it is good to keep it concise, but search-friendly. Data in this field can be stored in Markdown format to make your messages more pretty and easier to read. For more details [see](#markdown-in-events).
+```title``` | string       | no       | Event title, can be used as a short label for event, e.g. ```Elasticsearch restart```.
+```tags``` | string array     | no       | Multivalued field. Each tag should be specified as aseparate array element e.g., <br> ```"tags":[ "elasticsearch", "restart", "emergency fix"]```
+```severity``` | string | no | A single-valued field which says what kind of an event it is. It should have such values as ```error```,  ```info``` or ```warning``` and let's you easily navigate through important and less important events.
+```creator``` | string       | no       | Person, application, or component that created an event. E.g. ```John Smith```, ```Elasticsearch```, ```Some Batch Job```
+```data``` | string       | no       | Additional event data. It can be anything you may find useful to have along inside of event object. E.g., it could be  stacktrace in case of ```app_error``` event, base64 encoded content of file, etc.
+
+When you ship events to Sematext Cloud, we recommend you to use common fields listed in this page. This way you can easily correlate between your events, metrics and logs. For example, you see CPU usage spikes or start seeing more error logs and you want to investigate it further. You can use [Split Screen](../guide/split-screen) and load the Events in the right half and see if there was any deployment type of event that might be the cause of that spike. Or search for events that are shipped from a specific host that started using more resources than expected. This way you can pinpoint the source of the problems easily.
+
+### Types
+
+[Sematext Cloud](https://sematext.com/cloud/) helps you manage your events better and
+distinguish between different kinds of events when you provide event type as a ```JSON```
+field. There are no limitations to the number of possible values of ```type``` field. 
+To get the most value out of typed events we strongly suggest using a
+smaller number of distinct event types (1-10) to keep things manageable.
+Keeping the list of unique types concise help with faster navigation. Examples of
+recommended types: ```alert```, ```server-info```, ```deployment```, ```infra```,
+```outage```.
+
+
+Note: when using curl to call the Events API, you may experience **"SSL certificate
+problem"** errors. The reason is that curl doesn't bundle any CA certs
+any more.  For more info see
+[this](https://curl.haxx.se/docs/sslcerts.html). Regardless of curl
+errors, HTTPS communication should be successful.
+
+
+### Example of well defined event
+
+```json
+{
+  "timestamp": "2019-05-30T09:58:43.455Z",
+  "creator": "Jenkins",
+  "os.host": "jenkins-host",
+  "title": "Starting deployment",
+  "message": "Started deployment of Test v1.23 to production",
+  "severity": "info",
+  "type": "deployment",
+  "tags": ["version:1.23", "env:prod"],
+}
+```
+
+
+### Markdown in events
+
+Event message supports [markdown](https://daringfireball.net/projects/markdown/syntax).
+
+An example below. Notice message field which contains a text formatted with Markdown.
+
+```json
+{
+  "title": "Hello Sematext",
+  "message": "### Hello Sematext\nClick [link](https://sematext.com/ \"Sematext\") \n",
+  "tags": ["msg", "env:dev"],
+  "severity": "info"
+}
+```
+
+![Markdown](../images/events/markdown.png "Markdown")

--- a/docs/tags/common-schema.md
+++ b/docs/tags/common-schema.md
@@ -186,8 +186,6 @@ Below are tags that are reserved for future use:
 
 ## Events Tags
 
-### Fields
-
 When you create an event you can send a ```JSON``` document which consists of multiple
 fields. Each field can contain event main information or metadata. Even though there is
 no strict format of such a ```JSON``` document we recommend to some of fields. An event
@@ -198,20 +196,19 @@ Field Name | Field Type | Required | Notes
 ```timestamp``` | date       | no       | Time when event happened (if not specified,current time will be assumed). The format is [dateOptionalTime](https://joda-time.sourceforge.netapi-release/org/joda/time/format/ISODateTimeFormat.html#dateOptionalTimeParser) e.g.: ```2014-02-17T21:37:04+0100``` or```  2014-02-17T14:15:01.534471+02:00```.
 ```os.host``` | string       | no       | Name of the host where the event has occurred.
 ```type``` | string | yes | Event type which could be e.g. ```alert```, ```deployment```, etc. Events are later grouped in timeline based on event type which significantly improves visibility.
-```message``` | string       | yes       | Short description of event, e.g. ```Elasticsearch node03 onhost somehost06 restarted```. This is a default search field in Sematext UI, so it is good to keep it concise, but search-friendly. Data in this field can be stored in Markdown format to make your messages more pretty and easier to read. For more details [see](#markdown-in-events).
+```message``` | string       | yes       | Short description of event, e.g. ```Elasticsearch node03 on host somehost06 restarted```. This is a default search field in Sematext UI, so it is good to keep it concise, but search-friendly. Data in this field can be stored in Markdown format to make your messages more pretty and easier to read. For more details [see](#markdown-in-events).
 ```title``` | string       | no       | Event title, can be used as a short label for event, e.g. ```Elasticsearch restart```.
 ```tags``` | string array     | no       | Multivalued field. Each tag should be specified as aseparate array element e.g., <br> ```"tags":[ "elasticsearch", "restart", "emergency fix"]```
-```severity``` | string | no | A single-valued field which says what kind of an event it is. It should have such values as ```error```,  ```info``` or ```warning``` and let's you easily navigate through important and less important events.
+```severity``` | string | no | A single-valued field which says what kind of an event it is. It should have such values as ```error```,  ```info``` or ```warning``` and lets you easily navigate through important and less important events.
 ```creator``` | string       | no       | Person, application, or component that created an event. E.g. ```John Smith```, ```Elasticsearch```, ```Some Batch Job```
 ```data``` | string       | no       | Additional event data. It can be anything you may find useful to have along inside of event object. E.g., it could be  stacktrace in case of ```app_error``` event, base64 encoded content of file, etc.
 
-When you ship events to Sematext Cloud, we recommend you to use common fields listed in this page. This way you can easily correlate between your events, metrics and logs. For example, you see CPU usage spikes or start seeing more error logs and you want to investigate it further. You can use [Split Screen](../guide/split-screen) and load the Events in the right half and see if there was any deployment type of event that might be the cause of that spike. Or search for events that are shipped from a specific host that started using more resources than expected. This way you can pinpoint the source of the problems easily.
+When you ship events to Sematext Cloud, we recommend using the common fields listed in this page. This way you can easily correlate between your events, metrics and logs. For example, when you see CPU usage spikes or start seeing more error logs and you want to investigate it further. You can use [Split Screen](../guide/split-screen) and load the Events in the right half of the screen and see if there was any deployment type of event that might be the cause of that spike. Or search for events that are shipped from a specific host that started using more resources than expected. This way you can pinpoint the source of the problems easily.
 
 ### Types
 
 [Sematext Cloud](https://sematext.com/cloud/) helps you manage your events better and
-distinguish between different kinds of events when you provide event type as a ```JSON```
-field. There are no limitations to the number of possible values of ```type``` field. 
+distinguish between different kinds of events when you provide an event type. There are no limitations to the number of possible values of ```type``` field. 
 To get the most value out of typed events we strongly suggest using a
 smaller number of distinct event types (1-10) to keep things manageable.
 Keeping the list of unique types concise help with faster navigation. Examples of


### PR DESCRIPTION
I will remove https://sematext.com/docs/events/fields/ page after review to avoid duplicate content. And add a nav link at the bottom https://sematext.com/docs/events/adding/ page saying "See common Sematext Common Schema for recommended event fields."