### PR TITLE
Update fleet troubleshooting

### DIFF
--- a/docs/fleet/index.md
+++ b/docs/fleet/index.md
@@ -38,7 +38,9 @@ This panel contains a list of the Log Shippers installed on the host. If you cli
 The following status values are currently available for Log Shippers:
 
 * Running: The Log Shipper is running without issues
-* Not Configured: This is the initial state of Log Shipper. It means that it has not been configured yet in [Discovery](https://sematext.com/docs/logs/discovery/intro/), or another Log Shipper has been used to ship logs. Make sure to review the configuration of Log Shipper in [Discovery](https://sematext.com/docs/logs/discovery/intro/)
+* Not Configured: This is the initial state of Log Shipper. Potential causes:
+   * Log Shipper has not been configured yet in [Discovery](https://sematext.com/docs/logs/discovery/intro/), or another Log Shipper has been used to ship logs. Make sure to review the configuration of Log Shipper in [Discovery](https://sematext.com/docs/logs/discovery/intro/).
+   * If you are working in a Kubernetes environment, it may indicate issues with the permissions within a namespace or across the cluster. Check the Agent installation instructions to ensure that RBAC rules are set, and verify that all Kubernetes permissions have been properly configured.
 * Dead: The Sematext Agent started the Log Shipper but something went wrong. Usually, this means that the Log Shipper process is not available (bare metal), or the status of the Log Shipper container/pod is not running. You can [manually restart](https://sematext.com/docs/agents/sematext-agent/starting-stopping) the Sematext Agent
 * Init Failure: Systemd is not available (bare metal), there is an error pulling the Log Shipper container image, or there is an issue creating/starting the Log Shipper container/pod. Ensure that your system has enough resources to run the container/pod and confirm that you don't have issues with network connectivity to pull container images
 * Stopped: The Log Shipper process has been stopped by the Sematext Agent. You can [manually restart](https://sematext.com/docs/agents/sematext-agent/starting-stopping) the Sematext Agent


### PR DESCRIPTION
Added one more possible cause for the Log Shipper status "Not Configured", related with Kubernetes permissions.