### PR TITLE
SC-17986 restructure sematext monitoring

### DIFF
--- a/docs/monitoring/service-monitoring.md
+++ b/docs/monitoring/service-monitoring.md
@@ -1,0 +1,16 @@
+title: Service Monitoring
+description: Sematext Service Monitoring helps you monitor the performance of all your services using one of our available integrations with automatic service discovery and monitoring capabilities.
+
+Service Monitoring is designed to help you monitor the performance and health status of your services by relying only on the Sematext Agent, without any other requirements to modify your code. Through a large number of readily available integrations, you get all the needed performance and health metrics in highly configurable dashboards or scheduled reports, specifically created for each service type. 
+
+Each integration comes with prebuilt alerts based on fine-tuned thresholds, heartbeats, or anomalies detected by Sematext Cloud. No manual steps are needed for monitoring a service, everything is automatically discovered and configured through our service discovery functionality. Lastly, all the monitored services can be further correlated with their relevant logs to improve early identification of issues and time to resolution
+
+For more information make sure to check:
+
+- [Service Discovery](https://sematext.com/docs/monitoring/service-monitoring/autodiscovery/)
+- [Monitoring Integrations](https://sematext.com/docs/integration/#monitoring)
+- [Alerts](https://sematext.com/docs/alerts/)
+- [Dashboard Components and Reports](https://sematext.com/docs/monitoring/reports-and-components/)
+- [Scheduled Reports](https://sematext.com/docs/guide/scheduled-reports/)
+- [Correlation](https://sematext.com/docs/monitoring/correlation/)
+- [Connected Apps](https://sematext.com/docs/guide/connected-apps/)


### PR DESCRIPTION
This is a restructuring of docs > Monitoring to improve naming and content consistency 

- Side menu updates
  - Moved all Infrastructure Monitoring pages under "Infrastructure Monitoring" subsection
  - Added new "Service Monitoring" subsection 
  - Created Service Monitoring overview page
  - Moved autodiscovery under "Services Monitoring" subsection as "Service Discovery"
  - Removed "on demand profiling" and "network map" pages
  - Moved "JMX Monitoring" under Sematext Agent > Containers section