### PR TITLE
SC-16400 add default ARs in integrations

### DIFF
--- a/docs/integration/akka.md
+++ b/docs/integration/akka.md
@@ -5,6 +5,45 @@ description: Sematext APM monitoring integration for Akka actors, dispatchers, a
 
 - Instructions: [https://apps.sematext.com/ui/howto/Akka/overview](https://apps.sematext.com/ui/howto/Akka/overview)
 
+## Akka Default Alerts
+
+As soon as you create an Akka App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+
+### CPU idle < 5%
+
+This alert rule continuously monitors the CPU idle percentage in an Akka system, triggering a warning (WARN priority) when the CPU idle falls below 5%. The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an Akka system typically operates with CPU idle percentages above 5%. However, due to increased workload, the CPU idle percentage drops below 5%. When this happens, the alert rule  the alert rule triggers a warning.
+
+#### Actions to take
+
+- Review the resource usage of the Akka system to identify the cause of increased CPU usage and decreased idle percentage. This may involve analyzing application load, system configuration, and resource allocation
+
+### Network received anomaly
+
+This alert rule continuously monitors the rate of network data received by an Akka application, checking for anomalies in the received data rate over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an Akka application typically receives network data at a consistent rate, but due to network congestion or other issues, the rate of data reception suddenly drops or spikes unexpectedly. When this happens, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Check the status of the network infrastructure to determine if there are any issues such as congestion, packet loss, or connectivity problems affecting data reception
+- Review application logs and system metrics to identify any errors or warnings that may be impacting network data reception
+
+### Network transmitted anomaly
+
+This alert rule continuously monitors the rate of network transmission on the operating system level for Akka applications, checking for anomalies in transmission rates over time. When anomalies are detected, it triggers a warning (WARN priority).
+
+Suppose an Akka application typically maintains a stable rate of network transmission, but due to increased network congestion or connectivity issues, the transmission rate suddenly changes unexpectedly. When this happens, the alert rule checks for anomalies in the network transmission rate over the last hour. Upon detecting the anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Check for network connectivity issues that may be affecting the transmission rate
+- Review network configurations and adjust settings to optimize network performance
+
+You can [create additional alerts](https://sematext.com/docs/alerts) on any metric.
+
+
 ## Metrics
 
 Metric Name | Key | Agg | Type | Description

--- a/docs/integration/akka.md
+++ b/docs/integration/akka.md
@@ -7,7 +7,7 @@ description: Sematext APM monitoring integration for Akka actors, dispatchers, a
 
 ## Akka Default Alerts
 
-As soon as you create an Akka App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+As soon as you create an Akka App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will [notify](https://sematext.com/docs/alerts/alert-notifications/) you of important events that may require your attention, as shown below.
 
 ### CPU idle < 5%
 
@@ -28,7 +28,7 @@ Suppose an Akka application typically receives network data at a consistent rate
 #### Actions to take
 
 - Check the status of the network infrastructure to determine if there are any issues such as congestion, packet loss, or connectivity problems affecting data reception
-- Review application logs and system metrics to identify any errors or warnings that may be impacting network data reception
+- Review application logs and system metrics for any errors or warnings that may be impacting network data reception
 
 ### Network transmitted anomaly
 

--- a/docs/integration/elasticsearch-integration.md
+++ b/docs/integration/elasticsearch-integration.md
@@ -54,7 +54,7 @@ Last, but certainly not least, you may want to get an alert if a node leaves the
 
 ## Elasticsearch Default Alerts
 
-As soon as you create an Elasticsearch App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+As soon as you create an Elasticsearch App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will [notify](https://sematext.com/docs/alerts/alert-notifications/) you of important events that may require your attention, as shown below.
 
 ### Node count anomaly
 
@@ -104,12 +104,12 @@ Suppose an Elasticsearch cluster experiences a sudden increase in query load or 
 
 #### Actions to take
 
-- Analyze resource usage metrics for the Elasticsearch cluster, including CPU, memory, and disk utilization, to identify the source of the increased load
+- Analyze resource usage metrics for the Elasticsearch cluster, including CPU, memory, and disk utilization, to find the source of the increased load
 - Review and optimize search queries or indexing operations that may be contributing to the increased load on the cluster. Consider optimizing query performance, reducing indexing throughput
 
 ### Unassigned shards anomaly
 
-This alert rule continuously monitors the presence of unassigned shards in an Elasticsearch cluster, identifying anomalies in the number of unassigned shards over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the presence of unassigned shards in an Elasticsearch cluster, detecting anomalies in the number of unassigned shards over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose an Elasticsearch cluster typically maintains a low number of unassigned shards, but due to issues such as node failures or disk space constraints, the number of unassigned shards suddenly increases. When this happens, the alert rule checks for anomalies in the number of unassigned shards over the last 30 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
 
@@ -122,7 +122,7 @@ Suppose an Elasticsearch cluster typically maintains a low number of unassigned 
 
 ### Thread pool rejections anomaly
 
-This alert rule continuously monitors thread pool rejections in an Elasticsearch environment, identifying anomalies in the rate at which thread pool requests are rejected. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors thread pool rejections in an Elasticsearch environment, detecting anomalies in the rate at which thread pool requests are rejected. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose an Elasticsearch cluster experiences a sudden increase in thread pool rejections, potentially due to resource limitations or high query loads. When this happens, the alert rule checks for anomalies in thread pool rejections over the last 90 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
 
@@ -153,7 +153,7 @@ Suppose there is some activity detected in the swap usage on a node in the Elast
 
 #### Action to take
 
-- Review system resource metrics to identify any spikes or anomalies in CPU, memory, or disk usage that may be contributing to swap usage
+- Review system resource metrics to find any spikes or anomalies in CPU, memory, or disk usage that may be contributing to swap usage
 - Evaluate Elasticsearch configuration settings and adjust resource allocations as needed to optimize performance and prevent any swap usage
 
 ### Open files > 85%
@@ -164,7 +164,7 @@ Suppose an Elasticsearch cluster typically operates with a healthy percentage of
 
 #### Actions to take
 
-- Review resource usage metrics and system logs to identify any issues contributing to the high percentage of open files
+- Review resource usage metrics and system logs to find any issues contributing to the high percentage of open files
 - Review Elasticsearch cluster configuration settings and consider optimizing resource allocation and file management settings to better handle file usage and prevent excessive file opening
 
 ### Load average

--- a/docs/integration/elasticsearch-integration.md
+++ b/docs/integration/elasticsearch-integration.md
@@ -52,6 +52,134 @@ Last, but certainly not least, you may want to get an alert if a node leaves the
 
 ![Dropping nodes and relocation of shards](https://sematext.com/wp-content/uploads/2019/03/Screen-Shot-2019-03-26-at-10.59.52-1.png)
 
+## Elasticsearch Default Alerts
+
+As soon as you create an Elasticsearch App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+
+### Node count anomaly
+
+This alert rule continuously monitors the count of nodes in an Elasticsearch cluster, checking for anomalies in the number of nodes present within the cluster. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an Elasticsearch cluster typically maintains a stable number of nodes, but due to various factors such as node failures, scaling activities, or network issues, the node count experiences sudden changes. When this happens, the alert rule checks for anomalies in the count of nodes over the last 90 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Check the status of nodes within the Elasticsearch cluster for any nodes that may be offline, unavailable, or experiencing issues
+- If node failures are detected, you may need to restart failed nodes or replace hardware
+- If the node count changes due to scaling activities (e.g., adding or removing nodes), review the recent scaling events to confirm that they are intentional and expected
+- Monitor network connectivity between nodes within the Elasticsearch cluster for any network issues that may be affecting communication and node discovery
+
+
+### Java old gen usage > 97%
+
+This alert rule continuously monitors the usage of Java's old generation heap memory in an Elasticsearch environment, triggering a warning if the usage exceeds 97%. The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose the Java old generation heap memory usage in the Elasticsearch environment starts increasing and eventually exceeds 97% over a 5-minute period.
+
+#### Actions to take
+
+- Analyze the application's memory usage patterns for any memory leaks
+- Review and optimize the Java Virtual Machine (JVM) configuration, including heap size settings, garbage collection algorithms, and memory management parameters
+- Monitor system resources, including memory, CPU, and disk I/O, and consider scaling them up if necessary
+- Investigate recent application changes, updates, or deployments that may have contributed to the spike in memory usage
+
+### Field data size
+
+This alert rule continuously monitors the field data size in an Elasticsearch cluster and triggers a warning if the field data size exceeds a certain threshold (20 in this case). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose the field data size in the Elasticsearch cluster increases significantly due to increased query loads or inefficient queries. When this happens, the alert rule checks the field data size over the last 10 minutes. If it exceeds 20% of the JVM heap committed memory during this timeframe, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Analyze the query patterns and usage that contribute to the increased field data size. Look for inefficient or resource-intensive queries that may need optimization
+- Optimize queries to reduce the amount of field data loaded into memory. This may involve restructuring queries, using filters, or optimizing aggregations to minimize memory usage
+- Consider scaling up the resources allocated to the Elasticsearch cluster, such as increasing the JVM heap size, to accommodate the increased field data size
+
+
+### Tripped parent circuit breaker
+
+This alert rule continuously monitors the tripping of the parent circuit breaker in an Elasticsearch cluster, detecting instances where the circuit breaker has been triggered due to resource constraints or overload. When such instances are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an Elasticsearch cluster experiences a sudden increase in query load or indexing throughput, leading to resource contention and triggering the parent circuit breaker. When this happens, the alert rule checks for instances of the parent circuit breaker being tripped over the last 5 minutes. The alert is triggered as soon as the circuit breaker is tripped at least once within the specified timeframe.
+
+#### Actions to take
+
+- Analyze resource usage metrics for the Elasticsearch cluster, including CPU, memory, and disk utilization, to identify the source of the increased load
+- Review and optimize search queries or indexing operations that may be contributing to the increased load on the cluster. Consider optimizing query performance, reducing indexing throughput
+
+### Unassigned shards anomaly
+
+This alert rule continuously monitors the presence of unassigned shards in an Elasticsearch cluster, identifying anomalies in the number of unassigned shards over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an Elasticsearch cluster typically maintains a low number of unassigned shards, but due to issues such as node failures or disk space constraints, the number of unassigned shards suddenly increases. When this happens, the alert rule checks for anomalies in the number of unassigned shards over the last 30 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Check the status of Elasticsearch nodes to determine if any nodes are experiencing issues or are offline
+- Review disk space on Elasticsearch nodes to see if there is sufficient space available for shard allocation
+- Review shard allocation settings in the Elasticsearch cluster configuration to make sure that shards are allocated properly and evenly across nodes
+- Recover unassigned shards and allocate them to available nodes in the cluster
+
+### Thread pool rejections anomaly
+
+This alert rule continuously monitors thread pool rejections in an Elasticsearch environment, identifying anomalies in the rate at which thread pool requests are rejected. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an Elasticsearch cluster experiences a sudden increase in thread pool rejections, potentially due to resource limitations or high query loads. When this happens, the alert rule checks for anomalies in thread pool rejections over the last 90 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Review system metrics for the Elasticsearch cluster, including CPU, memory, and disk usage, for any resource constraints that may be contributing to thread pool rejections
+- Analyze query patterns for any inefficient or resource-intensive queries. Optimize queries to reduce the load on the cluster
+- Review thread pool configurations and adjust settings such as thread counts, queue sizes, and timeouts to better accommodate the workload and prevent thread pool saturation
+
+### Used memory > 80%
+
+This alert rule continuously monitors memory usage in an Elasticsearch environment and triggers a warning (WARN priority) when the used memory exceeds 80% of the total available memory. The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose the Elasticsearch cluster experiences a sudden increase in activity or data volume, leading to increased memory usage. When the used memory exceeds 80% of the total available memory, the alert rule checks memory usage over the last hour. Upon crossing the threshold, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Investigate the cause of increased memory usage in the Elasticsearch cluster, such as processes or activities contributing to the high memory consumption
+- Review and optimize the configuration settings of the Elasticsearch cluster, including heap size allocation and cache settings
+
+### Swap usage
+
+This alert rule continuously monitors swap usage in an Elasticsearch environment by tracking the rate of swap input/output operations. When any amount of swap usage is detected, it triggers a warning (WARN priority). This includes even the slightest swap activity, such as reading or writing a single byte to or from swap space.
+
+The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose there is some activity detected in the swap usage on a node in the Elasticsearch cluster. Despite the relatively small amount of swap activity, the alert rule triggers a warning to prevent any big (and potentially unacceptable) slowdowns in Elasticsearch caused by accessing swap memory.
+
+#### Action to take
+
+- Review system resource metrics to identify any spikes or anomalies in CPU, memory, or disk usage that may be contributing to swap usage
+- Evaluate Elasticsearch configuration settings and adjust resource allocations as needed to optimize performance and prevent any swap usage
+
+### Open files > 85%
+
+This alert rule continuously monitors the percentage of open files in an Elasticsearch cluster. When the percentage exceeds 85% within the specified timeframe, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an Elasticsearch cluster typically operates with a healthy percentage of open files, but due to increased usage or resource limitations, the percentage of open files exceeds 85%. When this happens, the alert rule checks for instances where the percentage of open files exceeds 85% within the last 10 minutes and triggers a warning.
+
+#### Actions to take
+
+- Review resource usage metrics and system logs to identify any issues contributing to the high percentage of open files
+- Review Elasticsearch cluster configuration settings and consider optimizing resource allocation and file management settings to better handle file usage and prevent excessive file opening
+
+### Load average
+
+This alert rule continuously monitors the load average of an Elasticsearch cluster and triggers a warning when the load average exceeds a specified threshold (currently when load average is more than 2). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose the average load on the Elasticsearch cluster typically remains below 2, but due to increased query loads or resource constraints, the load average spikes above 2. When this happens, the alert rule checks for load average values over the last 30 minutes. Upon detecting the load average anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+-  Review system metrics such as CPU, memory, and disk usage for any source of increased load on the Elasticsearch cluster
+- Review and optimize queries or indexing processes that may be contributing to the increased load on the cluster
+- If the increased load is due to resource limitations, consider scaling up resources such as CPU or memory
+
+
 ## Metrics
 
 Metric Name<br> Key *(Type)* *(Unit)*                                                                          |  Description

--- a/docs/integration/elasticsearch-integration.md
+++ b/docs/integration/elasticsearch-integration.md
@@ -179,6 +179,8 @@ Suppose the average load on the Elasticsearch cluster typically remains below 2,
 - Review and optimize queries or indexing processes that may be contributing to the increased load on the cluster
 - If the increased load is due to resource limitations, consider scaling up resources such as CPU or memory
 
+You can [create additional alerts](https://sematext.com/docs/alerts) on any metric.
+
 
 ## Metrics
 

--- a/docs/integration/elasticsearch-integration.md
+++ b/docs/integration/elasticsearch-integration.md
@@ -18,7 +18,9 @@ Having both Elasticsearch Logs and Monitoring Apps lets you correlate performanc
 To [explore logs and services](https://sematext.com/docs/monitoring/autodiscovery/) across multiple hosts, navigate to [Fleet & Discovery > Discovery > Services](https://apps.sematext.com/ui/fleet-and-discovery/discovery/services) (or  [Sematext Cloud Europe](https://apps.eu.sematext.com/ui/fleet-and-discovery/discovery/services)). From there, you can create additional [Apps](https://sematext.com/docs/guide/app-guide/) or stream data to existing ones without requiring any additional installations. 
 
 ## Important Metrics to Watch and Alert on
+
 ### System and JVM Metrics
+
 The first place we would recommend looking for in a new system are the OS metrics: CPU, memory, IO and network. A healthy CPU graph looks like this:
 
 ![CPU usage](https://sematext.com/wp-content/uploads/2019/03/Screen-Shot-2019-03-26-at-11.18.14-1.png)
@@ -34,7 +36,9 @@ When it comes to system memory, don't be worried if you see very little free, li
 ![System memory usage](https://sematext.com/wp-content/uploads/2019/03/Screen-Shot-2019-03-26-at-11.24.02-1.png)
 
 The operating system will try to cache your index files as much as it can. The *cached* memory can be freed up, if the system needs more memory.
+
 ### Elasticsearch-specific metrics
+
 You'll want to monitor query rates and times. In other words, how fast is Elasticsearch responding? Since this will likely impact your users, these are metrics worth alerting on as well.
 
 ![Query and fetch rate](https://sematext.com/wp-content/uploads/2019/03/Screen-Shot-2019-03-26-at-11.09.09-1.png)
@@ -95,9 +99,9 @@ Significant field data usage points to a misconfiguration. Normally, you'd only 
 
 ### Tripped parent circuit breaker
 
-This alert rule continuously monitors the tripping of the parent circuit breaker in an Elasticsearch cluster, detecting instances where the circuit breaker has been triggered due to resource constraints or overload. When such instances are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the tripping of the parent circuit breaker in an Elasticsearch cluster, detecting instances where the circuit breaker has been triggered usually due to very high memory usage (for real memory, current default is 95% of JVM heap). When such instances are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
-Suppose an Elasticsearch cluster experiences a sudden increase in query load or indexing throughput, leading to resource contention and triggering the parent circuit breaker. When this happens, the alert rule checks for instances of the parent circuit breaker being tripped over the last 5 minutes. The alert is triggered as soon as the circuit breaker is tripped at least once within the specified timeframe.
+Suppose an Elasticsearch cluster experiences a sudden increase in query load or indexing throughput, leading to very high memory usage and triggering the parent circuit breaker. When this happens, the alert rule checks for instances of the parent circuit breaker being tripped over the last 5 minutes. The alert is triggered as soon as the circuit breaker is tripped at least once within the specified timeframe.
 
 #### Actions to take
 

--- a/docs/integration/elasticsearch-integration.md
+++ b/docs/integration/elasticsearch-integration.md
@@ -65,6 +65,7 @@ Suppose an Elasticsearch cluster typically maintains a stable number of nodes, b
 #### Actions to take
 
 - Check the status of nodes within the Elasticsearch cluster for any nodes that may be offline, unavailable, or experiencing issues
+- Check the logs of the node that went down and/or logs of the master node
 - If node failures are detected, you may need to restart failed nodes or replace hardware
 - If the node count changes due to scaling activities (e.g., adding or removing nodes), review the recent scaling events to confirm that they are intentional and expected
 - Monitor network connectivity between nodes within the Elasticsearch cluster for any network issues that may be affecting communication and node discovery
@@ -72,29 +73,25 @@ Suppose an Elasticsearch cluster typically maintains a stable number of nodes, b
 
 ### Java old gen usage > 97%
 
-This alert rule continuously monitors the usage of Java's old generation heap memory in an Elasticsearch environment, triggering a warning if the usage exceeds 97%. The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the usage of Java's old generation heap memory in an Elasticsearch environment, triggering a warning if the usage exceeds 97%. Note that this shouldn't happen in a healthy environment. It's likely that the node will either face an out of memory exception or run into the Parent Circuit Breaker. Either way, you'd have unexpected failures. The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose the Java old generation heap memory usage in the Elasticsearch environment starts increasing and eventually exceeds 97% over a 5-minute period.
 
 #### Actions to take
 
-- Analyze the application's memory usage patterns for any memory leaks
-- Review and optimize the Java Virtual Machine (JVM) configuration, including heap size settings, garbage collection algorithms, and memory management parameters
-- Monitor system resources, including memory, CPU, and disk I/O, and consider scaling them up if necessary
+- [Review and optimize the Java Virtual Machine (JVM) configuration](https://sematext.com/blog/jvm-metrics/), including heap size settings, garbage collection algorithms, and memory management parameters
 - Investigate recent application changes, updates, or deployments that may have contributed to the spike in memory usage
 
 ### Field data size
 
 This alert rule continuously monitors the field data size in an Elasticsearch cluster and triggers a warning if the field data size exceeds a certain threshold (20 in this case). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
-Suppose the field data size in the Elasticsearch cluster increases significantly due to increased query loads or inefficient queries. When this happens, the alert rule checks the field data size over the last 10 minutes. If it exceeds 20% of the JVM heap committed memory during this timeframe, the alert rule triggers a warning.
+Significant field data usage points to a misconfiguration. Normally, you'd only use field data for global ordinals. If you're using >20%, you probably do sorting/aggregations on a text field with field data enabled. Which is dangerous (you may run out of heap on an expensive query). So you'd want to pre-process the data in the pipeline before Elasticsearch and do your sorting/aggregations on doc_values instead.
 
 #### Actions to take
 
-- Analyze the query patterns and usage that contribute to the increased field data size. Look for inefficient or resource-intensive queries that may need optimization
-- Optimize queries to reduce the amount of field data loaded into memory. This may involve restructuring queries, using filters, or optimizing aggregations to minimize memory usage
+- Check _cat/fielddata, it will tell you which fields use more field data
 - Consider scaling up the resources allocated to the Elasticsearch cluster, such as increasing the JVM heap size, to accommodate the increased field data size
-
 
 ### Tripped parent circuit breaker
 
@@ -106,10 +103,11 @@ Suppose an Elasticsearch cluster experiences a sudden increase in query load or 
 
 - Analyze resource usage metrics for the Elasticsearch cluster, including CPU, memory, and disk utilization, to find the source of the increased load
 - Review and optimize search queries or indexing operations that may be contributing to the increased load on the cluster. Consider optimizing query performance, reducing indexing throughput
+- Consider scaling up the resources allocated to the Elasticsearch cluster, such as increasing the JVM heap size and number of nodes
 
 ### Unassigned shards anomaly
 
-This alert rule continuously monitors the presence of unassigned shards in an Elasticsearch cluster, detecting anomalies in the number of unassigned shards over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the presence of [unassigned shards](https://sematext.com/blog/elasticsearch-unassigned-shards/) in an Elasticsearch cluster, detecting anomalies in the number of unassigned shards over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose an Elasticsearch cluster typically maintains a low number of unassigned shards, but due to issues such as node failures or disk space constraints, the number of unassigned shards suddenly increases. When this happens, the alert rule checks for anomalies in the number of unassigned shards over the last 30 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
 
@@ -118,7 +116,7 @@ Suppose an Elasticsearch cluster typically maintains a low number of unassigned 
 - Check the status of Elasticsearch nodes to determine if any nodes are experiencing issues or are offline
 - Review disk space on Elasticsearch nodes to see if there is sufficient space available for shard allocation
 - Review shard allocation settings in the Elasticsearch cluster configuration to make sure that shards are allocated properly and evenly across nodes
-- Recover unassigned shards and allocate them to available nodes in the cluster
+- Recover [unassigned shards](https://sematext.com/blog/elasticsearch-unassigned-shards/) and allocate them to available nodes in the cluster
 
 ### Thread pool rejections anomaly
 
@@ -129,19 +127,18 @@ Suppose an Elasticsearch cluster experiences a sudden increase in thread pool re
 #### Actions to take
 
 - Review system metrics for the Elasticsearch cluster, including CPU, memory, and disk usage, for any resource constraints that may be contributing to thread pool rejections
-- Analyze query patterns for any inefficient or resource-intensive queries. Optimize queries to reduce the load on the cluster
-- Review thread pool configurations and adjust settings such as thread counts, queue sizes, and timeouts to better accommodate the workload and prevent thread pool saturation
+- Analyze query patterns for any inefficient or resource-intensive queries. Optimize queries to reduce the load on the cluster (only applies for the search thread pool)
+- Check the calling applications and use fewer threads to talk to Elasticsearch
 
 ### Used memory > 80%
 
 This alert rule continuously monitors memory usage in an Elasticsearch environment and triggers a warning (WARN priority) when the used memory exceeds 80% of the total available memory. The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
-Suppose the Elasticsearch cluster experiences a sudden increase in activity or data volume, leading to increased memory usage. When the used memory exceeds 80% of the total available memory, the alert rule checks memory usage over the last hour. Upon crossing the threshold, the alert rule triggers a warning.
+If the heap size is set too high in the Elasticsearch configuration, it might lead to excessive memory usage. In such cases, when the heap memory usage goes over 80% of the total available memory, the alert rule checks memory usage over the last hour. Upon crossing the threshold, the alert rule triggers a warning.
 
 #### Actions to take
 
-- Investigate the cause of increased memory usage in the Elasticsearch cluster, such as processes or activities contributing to the high memory consumption
-- Review and optimize the configuration settings of the Elasticsearch cluster, including heap size allocation and cache settings
+- Review and optimize the configuration settings of the Elasticsearch cluster, including heap size allocation
 
 ### Swap usage
 
@@ -153,8 +150,7 @@ Suppose there is some activity detected in the swap usage on a node in the Elast
 
 #### Action to take
 
-- Review system resource metrics to find any spikes or anomalies in CPU, memory, or disk usage that may be contributing to swap usage
-- Evaluate Elasticsearch configuration settings and adjust resource allocations as needed to optimize performance and prevent any swap usage
+- Turn off swap usage
 
 ### Open files > 85%
 
@@ -164,8 +160,9 @@ Suppose an Elasticsearch cluster typically operates with a healthy percentage of
 
 #### Actions to take
 
-- Review resource usage metrics and system logs to find any issues contributing to the high percentage of open files
-- Review Elasticsearch cluster configuration settings and consider optimizing resource allocation and file management settings to better handle file usage and prevent excessive file opening
+- Verify and adjust open file limits for Elasticsearch processes. The default open file limit for most systems is 65,536
+- If the open file limit is approaching the recommended threshold, check unusual merge policies or a large number of very small shards
+- A high percentage of open files usually signals a misconfiguration. Review Elasticsearch cluster configuration settings and consider optimizing resource allocation and file management settings to better handle file usage and prevent excessive file opening
 
 ### Load average
 
@@ -175,7 +172,7 @@ Suppose the average load on the Elasticsearch cluster typically remains below 2,
 
 #### Actions to take
 
--  Review system metrics such as CPU, memory, and disk usage for any source of increased load on the Elasticsearch cluster
+- Review thread pools, indexing and search operations, heap usage, etc.
 - Review and optimize queries or indexing processes that may be contributing to the increased load on the cluster
 - If the increased load is due to resource limitations, consider scaling up resources such as CPU or memory
 

--- a/docs/integration/hbase.md
+++ b/docs/integration/hbase.md
@@ -7,11 +7,11 @@ description: Sematext HBase monitoring captures all key HBase metrics with out o
 
 ## HBase Alerts
 
-As soon as you create an HBase App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+As soon as you create an HBase App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will [notify](https://sematext.com/docs/alerts/alert-notifications/) you of important events that may require your attention, as shown below.
 
 ### Node count anomaly
 
-This alert rule continuously monitors the count of nodes running HBase regions in a system, identifying anomalies in the node count over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the count of nodes running HBase regions in a system, detecting anomalies in the node count over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose a system typically maintains a consistent number of servers running HBase regions, but due to hardware failures, scaling events, or maintenance activities, the node count changes unexpectedly. When this happens, the alert rule checks for anomalies in the node count over the last 90 minutes. Upon detecting the anomaly in the node count, the alert rule triggers a warning.
 

--- a/docs/integration/hbase.md
+++ b/docs/integration/hbase.md
@@ -5,6 +5,23 @@ description: Sematext HBase monitoring captures all key HBase metrics with out o
 
 - Instructions: [https://apps.sematext.com/ui/howto/HBase/overview](https://apps.sematext.com/ui/howto/HBase/overview)
 
+## HBase Alerts
+
+As soon as you create an HBase App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+
+### Node count anomaly
+
+This alert rule continuously monitors the count of nodes running HBase regions in a system, identifying anomalies in the node count over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose a system typically maintains a consistent number of servers running HBase regions, but due to hardware failures, scaling events, or maintenance activities, the node count changes unexpectedly. When this happens, the alert rule checks for anomalies in the node count over the last 90 minutes. Upon detecting the anomaly in the node count, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Investigate the reasons behind the observed changes in the node count, such as hardware failures, scaling events, or maintenance activities
+- If the node count decrease is due to hardware failures, replace or repair the failed hardware components
+
+You can [create additional alerts](https://sematext.com/docs/alerts) on any metric.
+
 ## Metrics
 
 You can choose which of some 300 HBase metrics to collect by adjusting the [HBase integration YML files](https://github.com/sematext/sematext-agent-integrations/tree/master/hbase) once you [install the HBase monitoring agent](https://apps.sematext.com/ui/howto/HBase/overview).

--- a/docs/integration/jenkins.md
+++ b/docs/integration/jenkins.md
@@ -5,6 +5,53 @@ description: Comprehensive view of your Jenkins health and performance with Sema
 
 - Instructions: [https://apps.sematext.com/ui/howto/Jenkins/overview](https://apps.sematext.com/ui/howto/Jenkins/overview)
 
+
+## Jenkins Alerts
+
+As soon as you create a Jenkins App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+
+
+### Health check score anomaly
+This alert rule continuously monitors the health check score (the ratio of successful health checks to total health checks) of Jenkins instances using [anomaly detection](https://sematext.com/docs/alerts/#alert-types). When anomalies are detected, it triggers warnings (WARN priority) and sends you a [notification](https://sematext.com/docs/alerts/alert-notifications/).
+
+Let's say you have a Jenkins server that typically has a health check score of around 0.9, indicating a healthy system. However, due to a sudden increase in system load or a misconfiguration, the health check score drops significantly to 0.5 within a short period. Upon detecting the anomaly (in this case, a sudden drop in the health check score), the alert rule triggers a warning and sends notifications to the designated recipients.
+
+#### Actions to take
+
+- You can examine [system metrics](https://sematext.com/docs/monitoring/infrastructure/) such as CPU usage, memory, disk I/O, and network traffic to identify any spikes that may have contributed to the drop in the health check score
+- Review Jenkins logs (system log, build logs, and any plugin-specific logs) to get insights into any errors or warnings in the Jenkins environment
+- Review recent changes to Jenkins configuration, including plugin updates, job configurations, and system settings
+
+
+### Response with Server Error Code
+
+This alert rule continuously monitors the count of HTTP 500 server errors in the Jenkins master Web UI. When the count exceeds zero within the last 5 minutes, it triggers a warning (WARN priority). The minimum delay between consecutive notifications triggered by this alert rule is set to 10 minutes.
+
+Suppose the Jenkins master Web UI typically operates smoothly, but due to a misconfiguration or software bug, it starts responding with HTTP 500 errors. The alert rule checks for occurrences of HTTP 500 errors within the last 5 minutes and it's triggered as soon as a single HTTP 500 error occurs.
+
+#### Actions to take
+
+- Review Jenkins logs and server configurations to identify the cause of the HTTP 500 errors. This may involve checking for misconfigurations, software bugs, or issues with dependencies
+- If recent changes were made to Jenkins or its dependencies, consider rolling back those changes to restore stability
+
+
+### Server unavailable response code
+
+This alert rule continuously monitors the count of HTTP 503 server unavailable errors in the Jenkins master Web UI. When the count exceeds zero within the last 5 minutes, it triggers a warning (WARN priority). The minimum delay between consecutive notifications triggered by this alert rule is set to 10 minutes.
+
+Suppose the Jenkins master Web UI experiences a sudden surge in traffic or encounters issues with backend services, leading to an increase in HTTP 503 errors. When this happens, the alert rule checks for occurrences of HTTP 503 errors within the last 5 minutes and is triggered as soon as a single HTTP 503 error occurs.
+
+#### Actions to take
+
+- Investigate the status and health of backend services that Jenkins depends on, such as databases, application servers, or external APIs
+- Check Jenkins configuration settings, including connection settings to external integrations, resource allocation, and plugin configurations
+- [Monitor resource usage](https://sematext.com/docs/monitoring/infrastructure/) on the Jenkins server, including CPU, memory, disk I/O, and network bandwidth
+- If Jenkins is experiencing high traffic, consider scaling up the infrastructure by adding more Jenkins nodes
+
+
+You can [create additional alerts](https://sematext.com/docs/alerts) on any metric.
+
+
 ## Metrics
 
 Metric Key *(Type)* *(Unit)*                                                                             |  Description

--- a/docs/integration/jenkins.md
+++ b/docs/integration/jenkins.md
@@ -8,17 +8,18 @@ description: Comprehensive view of your Jenkins health and performance with Sema
 
 ## Jenkins Alerts
 
-As soon as you create a Jenkins App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+As soon as you create a Jenkins App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will [notify](https://sematext.com/docs/alerts/alert-notifications/) you of important events that may require your attention, as shown below.
 
 
 ### Health check score anomaly
-This alert rule continuously monitors the health check score (the ratio of successful health checks to total health checks) of Jenkins instances using [anomaly detection](https://sematext.com/docs/alerts/#alert-types). When anomalies are detected, it triggers warnings (WARN priority) and sends you a [notification](https://sematext.com/docs/alerts/alert-notifications/).
 
-Let's say you have a Jenkins server that typically has a health check score of around 0.9, indicating a healthy system. However, due to a sudden increase in system load or a misconfiguration, the health check score drops significantly to 0.5 within a short period. Upon detecting the anomaly (in this case, a sudden drop in the health check score), the alert rule triggers a warning and sends notifications to the designated recipients.
+This alert rule continuously monitors the health check score (the ratio of successful health checks to total health checks) of Jenkins instances using [anomaly detection](https://sematext.com/docs/alerts/#alert-types). When anomalies are detected, it triggers warnings (WARN priority).
+
+Let's say you have a Jenkins server that typically has a health check score of around 0.9, indicating a healthy system. However, due to a sudden increase in system load or a misconfiguration, the health check score drops significantly to 0.5 within a short period. Upon detecting the anomaly (in this case, a sudden drop in the health check score), the alert rule triggers a warning.
 
 #### Actions to take
 
-- You can examine [system metrics](https://sematext.com/docs/monitoring/infrastructure/) such as CPU usage, memory, disk I/O, and network traffic to identify any spikes that may have contributed to the drop in the health check score
+- You can examine [system metrics](https://sematext.com/docs/monitoring/infrastructure/) such as CPU usage, memory, disk I/O, and network traffic to find any spikes that may have contributed to the drop in the health check score
 - Review Jenkins logs (system log, build logs, and any plugin-specific logs) to get insights into any errors or warnings in the Jenkins environment
 - Review recent changes to Jenkins configuration, including plugin updates, job configurations, and system settings
 
@@ -31,7 +32,7 @@ Suppose the Jenkins master Web UI typically operates smoothly, but due to a misc
 
 #### Actions to take
 
-- Review Jenkins logs and server configurations to identify the cause of the HTTP 500 errors. This may involve checking for misconfigurations, software bugs, or issues with dependencies
+- Review Jenkins logs and server configurations to find the cause of the HTTP 500 errors. This may involve checking for misconfigurations, software bugs, or issues with dependencies
 - If recent changes were made to Jenkins or its dependencies, consider rolling back those changes to restore stability
 
 

--- a/docs/integration/kafka.md
+++ b/docs/integration/kafka.md
@@ -175,6 +175,8 @@ Suppose a Kafka consumer client typically processes messages without significant
 
 - Review Kafka consumer client configurations, message processing logic and system metrics to find the underlying cause of the increased lag
 - If the increased lag is due to limited resources, consider scaling up Kafka consumer client resources such as CPU, memory, or network bandwidth
+- Consider increasing the number of partitions for the relevant topics to distribute the load more evenly across consumers
+- Consider increasing the number of consumer instances to reduce lag
 
 
 ### In-sync replicas anomaly
@@ -224,7 +226,7 @@ Suppose a Kafka cluster typically maintains full replication of partitions acros
 
 - Check the status of Kafka brokers for any broker failures or issues that may be causing partitions to become under-replicated
 - Review the replication configurations for affected topics and partitions and double check that replication factors are set correctly
-- AAddress any network issues or connectivity problems between Kafka brokers that may be impacting the replication of partitions
+- Address any network issues or connectivity problems between Kafka brokers that may be impacting the replication of partitions
 - Consider rebalancing partitions across brokers to have even distribution and optimal replication, especially if certain brokers are overloaded or underutilized
 
 
@@ -239,7 +241,7 @@ Suppose a Kafka cluster typically maintains all partitions online and available 
 - Check the status of Kafka brokers for any broker failures or issues that may be causing partitions to become offline
 - Review the replication status and configuration of affected partitions to understand why they became offline. Determine if there are any replication issues or failures
 - If offline partitions are due to broker failures, try to recover or replace the failed brokers and make sure that partitions are redistributed and replicated properly
-- If offline partitions are due to disk failures or storage issues, address the underlying disk failures and mae sure that Kafka data directories are accessible and properly configured
+- If offline partitions are due to disk failures or storage issues, address the underlying disk failures and make sure that Kafka data directories are accessible and properly configured
 - Monitor the reassignment of offline partitions so that they are brought back online and replicated across available brokers effectively
 - Review data retention policies and disk space management to prevent future occurrences of offline partitions due to disk space issues
 

--- a/docs/integration/kafka.md
+++ b/docs/integration/kafka.md
@@ -163,23 +163,23 @@ The Sematext Kafka monitoring agent collects the following metrics.
 
 
 ## Kafka Alerts
-As soon as you create a Kafka App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+As soon as you create a Kafka App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will [notify](https://sematext.com/docs/alerts/alert-notifications/) you of important events that may require your attention, as shown below.
 
 ### Consumer lag anomaly
 
-This alert rule continuously monitors consumer lag in Kafka consumer clients, identifying anomalies in lag values over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive notifications triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors consumer lag in Kafka consumer clients, detecting anomalies in lag values over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive notifications triggered by this alert rule is set to 10 minutes.
 
 Suppose a Kafka consumer client typically processes messages without significant lag, but due to increased message volume or processing issues, the consumer lag suddenly spikes beyond normal levels. When this happens, the alert rule checks for anomalies in consumer lag values over the last 90 minutes and triggers a warning.
 
 #### Actions to take
 
-- Review Kafka consumer client configurations, message processing logic and system metrics to identify the underlying cause of the increased lag
+- Review Kafka consumer client configurations, message processing logic and system metrics to find the underlying cause of the increased lag
 - If the increased lag is due to limited resources, consider scaling up Kafka consumer client resources such as CPU, memory, or network bandwidth
 
 
 ### In-sync replicas anomaly
 
-This alert rule continuously monitors the number of in-sync replicas (ISRs) in a Kafka cluster, identifying anomalies in ISR counts over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the number of in-sync replicas (ISRs) in a Kafka cluster, detecting anomalies in ISR counts over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose a Kafka cluster typically maintains a stable number of in-sync replicas across its brokers. However, due to network issues or broker failures, the number of in-sync replicas starts changing unexpectedly. When this happens, the alert rule checks for anomalies in the number of in-sync replicas over the last 10 minutes. Upon detecting the anomaly in ISR counts, the alert rule triggers a warning.
 
@@ -192,7 +192,7 @@ Suppose a Kafka cluster typically maintains a stable number of in-sync replicas 
 
 ### Producer error rate anomaly
 
-This alert rule continuously monitors the error rate of Kafka producers, identifying anomalies in the rate at which producer records encounter errors during message sending. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the error rate of Kafka producers, detecting anomalies in the rate at which producer records encounter errors during message sending. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose a Kafka producer typically sends messages without getting errors, but due to network issues or limited resources, the errror rate of producer records suddenly spikes. When this happens, the alert rule checks for anomalies in the error rate of producer records over the last 10 minutes and upon detecting an anomaly it triggers a warning.
 
@@ -204,7 +204,7 @@ Suppose a Kafka producer typically sends messages without getting errors, but du
 
 ### Producer topic records error rate anomaly
 
-This alert rule continuously monitors the error rate of Kafka producer records at the topic level, identifying anomalies in the rate at which records encounter errors during message sending for specific topics. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the error rate of Kafka producer records at the topic level, detecting anomalies in the rate at which records encounter errors during message sending for specific topics. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose a Kafka producer typically sends messages to multiple topics without encountering errors, but due to issues with specific topics or data ingestion processes, the error rate of producer records for certain topics suddenly spikes. When this happens, the alert rule checks for anomalies in the error rate of producer records for specific topics over the last 10 minutes. Upon detecting the anomaly the alert rule triggers a warning.
 
@@ -216,7 +216,7 @@ Suppose a Kafka producer typically sends messages to multiple topics without enc
 
 ### Underreplicated partition count anomaly
 
-This alert rule continuously monitors the count of under-replicated partitions in a Kafka cluster, identifying anomalies in the number of partitions that are not fully replicated across all brokers. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the count of under-replicated partitions in a Kafka cluster, detecting anomalies in the number of partitions that are not fully replicated across all brokers. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose a Kafka cluster typically maintains full replication of partitions across all brokers, but due to broker failures, network issues, or limited resources, some partitions become under-replicated. When this happens, the alert rule checks for anomalies in the count of under-replicated partitions over the last 10 minutes. Upon detecting the anomaly in the count of under-replicated partitions, the alert rule triggers a warning.
 
@@ -230,7 +230,7 @@ Suppose a Kafka cluster typically maintains full replication of partitions acros
 
 ### Offline partition count anomaly
 
-This alert rule continuously monitors the count of offline partitions in a Kafka cluster, identifying anomalies in the number of partitions that are currently offline and unavailable. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the count of offline partitions in a Kafka cluster, detecting anomalies in the number of partitions that are currently offline and unavailable. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose a Kafka cluster typically maintains all partitions online and available for data replication and consumption. However, due to broker failures, disk failures, or other issues, some partitions become offline and unavailable. When this happens, the alert rule checks for anomalies in the count of offline partitions over the last 10 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
 
@@ -245,7 +245,7 @@ Suppose a Kafka cluster typically maintains all partitions online and available 
 
 ### Failed fetch requests anomaly
 
-This alert rule continuously monitors the count of failed fetch requests in a Kafka broker for topics, identifying anomalies in the number of requests that fail to fetch data. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the count of failed fetch requests in a Kafka broker for topics, detecting anomalies in the number of requests that fail to fetch data. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose a Kafka broker typically handles fetch requests without encountering failures, but due to network issues, disk failures, or other factors, some fetch requests begin to fail intermittently. When this happens, the alert rule checks for anomalies in the count of failed fetch requests over the last 10 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
 

--- a/docs/integration/kafka.md
+++ b/docs/integration/kafka.md
@@ -252,11 +252,12 @@ Suppose a Kafka broker typically handles fetch requests without encountering fai
 #### Actions to take
 
 - Check the status of the Kafka broker for any issues such as network connectivity problems, disk failures, or resource constraints that may be causing fetch requests to fail
-- Review disk utilization metrics for the Kafka broker to ensure that there is sufficient disk space available for storing topic data and handling fetch requests
+- Review disk utilization metrics for the Kafka broker to make sure that there is sufficient disk space available for storing topic data and handling fetch requests
 - Review network configurations and connectivity between the Kafka broker and clients for any network issues that may be causing fetch request failures
-- Monitor disk I/O metrics for the Kafka broker to identify any bottlenecks or performance issues related to disk read/write operations
+- Monitor disk I/O metrics for the Kafka broker for any bottlenecks or performance issues related to disk read/write operations
 - Review fetch request settings such as fetch size, timeout, and max fetch retries
 
+You can [create additional alerts](https://sematext.com/docs/alerts) on any metric.
 
 ## Troubleshooting
 

--- a/docs/integration/kafka.md
+++ b/docs/integration/kafka.md
@@ -161,6 +161,103 @@ The Sematext Kafka monitoring agent collects the following metrics.
 
 ![](https://sematext.com/wp-content/uploads/2019/05/d_kafka_consumer_lag.png)
 
+
+## Kafka Alerts
+As soon as you create a Kafka App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+
+### Consumer lag anomaly
+
+This alert rule continuously monitors consumer lag in Kafka consumer clients, identifying anomalies in lag values over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive notifications triggered by this alert rule is set to 10 minutes.
+
+Suppose a Kafka consumer client typically processes messages without significant lag, but due to increased message volume or processing issues, the consumer lag suddenly spikes beyond normal levels. When this happens, the alert rule checks for anomalies in consumer lag values over the last 90 minutes and triggers a warning.
+
+#### Actions to take
+
+- Review Kafka consumer client configurations, message processing logic and system metrics to identify the underlying cause of the increased lag
+- If the increased lag is due to limited resources, consider scaling up Kafka consumer client resources such as CPU, memory, or network bandwidth
+
+
+### In-sync replicas anomaly
+
+This alert rule continuously monitors the number of in-sync replicas (ISRs) in a Kafka cluster, identifying anomalies in ISR counts over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose a Kafka cluster typically maintains a stable number of in-sync replicas across its brokers. However, due to network issues or broker failures, the number of in-sync replicas starts changing unexpectedly. When this happens, the alert rule checks for anomalies in the number of in-sync replicas over the last 10 minutes. Upon detecting the anomaly in ISR counts, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Check the status of Kafka brokers to determine if any brokers have become unavailable or are experiencing issues
+- Review network configurations and connectivity between Kafka brokers for any network issues affecting communication and replication
+- If brokers have become unavailable, restore replication and make sure that all partitions have the required number of in-sync replicas
+
+
+### Producer error rate anomaly
+
+This alert rule continuously monitors the error rate of Kafka producers, identifying anomalies in the rate at which producer records encounter errors during message sending. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose a Kafka producer typically sends messages without getting errors, but due to network issues or limited resources, the errror rate of producer records suddenly spikes. When this happens, the alert rule checks for anomalies in the error rate of producer records over the last 10 minutes and upon detecting an anomaly it triggers a warning.
+
+#### Actions to take
+
+- Check the status of Kafka producers to see if any producers are experiencing issues or errors
+- Review network configurations and connectivity between Kafka producers and brokers for any network issues affecting message sending
+
+
+### Producer topic records error rate anomaly
+
+This alert rule continuously monitors the error rate of Kafka producer records at the topic level, identifying anomalies in the rate at which records encounter errors during message sending for specific topics. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose a Kafka producer typically sends messages to multiple topics without encountering errors, but due to issues with specific topics or data ingestion processes, the error rate of producer records for certain topics suddenly spikes. When this happens, the alert rule checks for anomalies in the error rate of producer records for specific topics over the last 10 minutes. Upon detecting the anomaly the alert rule triggers a warning.
+
+#### Actions to take
+- Investigate which specific Kafka topics are experiencing an increased error rate in producer records. This can be done by examining the topic-level error rate metrics
+- Review the configuration settings for the affected Kafka topics, including replication factor, partitioning strategy, and retention policy. Make sure that the configurations align with the expected workload
+- Review the configuration settings for Kafka producers, such as batch size, linger time, compression type, and retries
+
+
+### Underreplicated partition count anomaly
+
+This alert rule continuously monitors the count of under-replicated partitions in a Kafka cluster, identifying anomalies in the number of partitions that are not fully replicated across all brokers. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose a Kafka cluster typically maintains full replication of partitions across all brokers, but due to broker failures, network issues, or limited resources, some partitions become under-replicated. When this happens, the alert rule checks for anomalies in the count of under-replicated partitions over the last 10 minutes. Upon detecting the anomaly in the count of under-replicated partitions, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Check the status of Kafka brokers for any broker failures or issues that may be causing partitions to become under-replicated
+- Review the replication configurations for affected topics and partitions and double check that replication factors are set correctly
+- AAddress any network issues or connectivity problems between Kafka brokers that may be impacting the replication of partitions
+- Consider rebalancing partitions across brokers to have even distribution and optimal replication, especially if certain brokers are overloaded or underutilized
+
+
+### Offline partition count anomaly
+
+This alert rule continuously monitors the count of offline partitions in a Kafka cluster, identifying anomalies in the number of partitions that are currently offline and unavailable. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose a Kafka cluster typically maintains all partitions online and available for data replication and consumption. However, due to broker failures, disk failures, or other issues, some partitions become offline and unavailable. When this happens, the alert rule checks for anomalies in the count of offline partitions over the last 10 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Check the status of Kafka brokers for any broker failures or issues that may be causing partitions to become offline
+- Review the replication status and configuration of affected partitions to understand why they became offline. Determine if there are any replication issues or failures
+- If offline partitions are due to broker failures, try to recover or replace the failed brokers and make sure that partitions are redistributed and replicated properly
+- If offline partitions are due to disk failures or storage issues, address the underlying disk failures and mae sure that Kafka data directories are accessible and properly configured
+- Monitor the reassignment of offline partitions so that they are brought back online and replicated across available brokers effectively
+- Review data retention policies and disk space management to prevent future occurrences of offline partitions due to disk space issues
+
+### Failed fetch requests anomaly
+
+This alert rule continuously monitors the count of failed fetch requests in a Kafka broker for topics, identifying anomalies in the number of requests that fail to fetch data. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose a Kafka broker typically handles fetch requests without encountering failures, but due to network issues, disk failures, or other factors, some fetch requests begin to fail intermittently. When this happens, the alert rule checks for anomalies in the count of failed fetch requests over the last 10 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Check the status of the Kafka broker for any issues such as network connectivity problems, disk failures, or resource constraints that may be causing fetch requests to fail
+- Review disk utilization metrics for the Kafka broker to ensure that there is sufficient disk space available for storing topic data and handling fetch requests
+- Review network configurations and connectivity between the Kafka broker and clients for any network issues that may be causing fetch request failures
+- Monitor disk I/O metrics for the Kafka broker to identify any bottlenecks or performance issues related to disk read/write operations
+- Review fetch request settings such as fetch size, timeout, and max fetch retries
+
+
 ## Troubleshooting
 
 If you are having issues with Sematext Monitoring, i.e. not seeing Kafka metrics, see

--- a/docs/integration/opensearch-integration.md
+++ b/docs/integration/opensearch-integration.md
@@ -40,6 +40,135 @@ OpenSearch runs within a Java Virtual Machine (JVM) and [monitoring JVM](https:/
 
 Finally, high disk reads and writes can indicate a poorly tuned system. Since accessing the disk is an expensive process in terms of time, a well-tuned system should reduce disk I/O wherever possible.
 
+
+## OpenSearch Default Alerts
+
+As soon as you create an OpenSearch App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+
+### Node count anomaly
+
+This alert rule continuously monitors the count of nodes in an OpenSearch cluster, checking for anomalies in the number of nodes present within the cluster. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an OpenSearch cluster typically maintains a stable number of nodes, but due to various factors such as node failures, scaling activities, or network issues, the node count experiences sudden changes. When this happens, the alert rule checks for anomalies in the count of nodes over the last 90 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Check the status of nodes within the OpenSearch cluster for any nodes that may be offline, unavailable, or experiencing issues
+- If node failures are detected, you may need to restart failed nodes or replace hardware
+- If the node count changes due to scaling activities (e.g., adding or removing nodes), review the recent scaling events to confirm that they are intentional and expected
+- Monitor network connectivity between nodes within the OpenSearch cluster for any network issues that may be affecting communication and node discovery
+
+
+### Java old gen usage > 97%
+
+This alert rule continuously monitors the usage of Java's old generation heap memory in an OpenSearch environment, triggering a warning if the usage exceeds 97%. The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose the Java old generation heap memory usage in the OpenSearch environment starts increasing and eventually exceeds 97% over a 5-minute period.
+
+#### Actions to take
+
+- Analyze the application's memory usage patterns for any memory leaks
+- Review and optimize the Java Virtual Machine (JVM) configuration, including heap size settings, garbage collection algorithms, and memory management parameters
+- Monitor system resources, including memory, CPU, and disk I/O, and consider scaling them up if necessary
+- Investigate recent application changes, updates, or deployments that may have contributed to the spike in memory usage
+
+### Field data size
+
+This alert rule continuously monitors the field data size in an OpenSearch cluster and triggers a warning if the field data size exceeds a certain threshold (20 in this case). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose the field data size in the OpenSearch cluster increases significantly due to increased query loads or inefficient queries. When this happens, the alert rule checks the field data size over the last 10 minutes. If it exceeds 20% of the JVM heap committed memory during this timeframe, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Analyze the query patterns and usage that contribute to the increased field data size. Look for inefficient or resource-intensive queries that may need optimization
+- Optimize queries to reduce the amount of field data loaded into memory. This may involve restructuring queries, using filters, or optimizing aggregations to minimize memory usage
+- Consider scaling up the resources allocated to the OpenSearch cluster, such as increasing the JVM heap size, to accommodate the increased field data size
+
+
+### Tripped parent circuit breaker
+
+This alert rule continuously monitors the tripping of the parent circuit breaker in an OpenSearch cluster, detecting instances where the circuit breaker has been triggered due to resource constraints or overload. When such instances are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an OpenSearch cluster experiences a sudden increase in query load or indexing throughput, leading to resource contention and triggering the parent circuit breaker. When this happens, the alert rule checks for instances of the parent circuit breaker being tripped over the last 5 minutes. The alert is triggered as soon as the circuit breaker is tripped at least once within the specified timeframe.
+
+#### Actions to take
+
+- Analyze resource usage metrics for the OpenSearch cluster, including CPU, memory, and disk utilization, to identify the source of the increased load
+- Review and optimize search queries or indexing operations that may be contributing to the increased load on the cluster. Consider optimizing query performance, reducing indexing throughput
+
+### Unassigned shards anomaly
+
+This alert rule continuously monitors the presence of unassigned shards in an OpenSearch cluster, identifying anomalies in the number of unassigned shards over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an OpenSearch cluster typically maintains a low number of unassigned shards, but due to issues such as node failures or disk space constraints, the number of unassigned shards suddenly increases. When this happens, the alert rule checks for anomalies in the number of unassigned shards over the last 30 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Check the status of OpenSearch nodes to determine if any nodes are experiencing issues or are offline
+- Review disk space on OpenSearch nodes to see if there is sufficient space available for shard allocation
+- Review shard allocation settings in the OpenSearch cluster configuration to make sure that shards are allocated properly and evenly across nodes
+- Recover unassigned shards and allocate them to available nodes in the cluster
+
+### Thread pool rejections anomaly
+
+This alert rule continuously monitors thread pool rejections in an OpenSearch environment, identifying anomalies in the rate at which thread pool requests are rejected. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an OpenSearch cluster experiences a sudden increase in thread pool rejections, potentially due to resource limitations or high query loads. When this happens, the alert rule checks for anomalies in thread pool rejections over the last 90 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Review system metrics for the OpenSearch cluster, including CPU, memory, and disk usage, for any resource constraints that may be contributing to thread pool rejections
+- Analyze query patterns for any inefficient or resource-intensive queries. Optimize queries to reduce the load on the cluster
+- Review thread pool configurations and adjust settings such as thread counts, queue sizes, and timeouts to better accommodate the workload and prevent thread pool saturation
+
+### Used memory > 80%
+
+This alert rule continuously monitors memory usage in an OpenSearch environment and triggers a warning (WARN priority) when the used memory exceeds 80% of the total available memory. The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose the OpenSearch cluster experiences a sudden increase in activity or data volume, leading to increased memory usage. When the used memory exceeds 80% of the total available memory, the alert rule checks memory usage over the last hour. Upon crossing the threshold, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Investigate the cause of increased memory usage in the OpenSearch cluster, such as processes or activities contributing to the high memory consumption
+- Review and optimize the configuration settings of the OpenSearch cluster, including heap size allocation and cache settings
+
+### Swap usage
+
+This alert rule continuously monitors swap usage in an OpenSearch environment by tracking the rate of swap input/output operations. When swap usage exceeds the specified threshold, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose the swap usage on a node in the OpenSearch cluster suddenly spikes, indicating potential resource constraints or performance issues. When this happens, the alert rule checks for swap usage over the last 10 minutes. The alert is triggered when the sum of swap input/output operations within the specified timeframe is more than 1 (the threshold value).
+
+#### Action to take
+
+- Review system resource metrics to identify any spikes or anomalies in CPU, memory, or disk usage that may be contributing to high swap usage
+- Evaluate OpenSearch configuration settings and adjust resource allocations as needed to optimize performance and prevent excessive swap usage
+
+### Open files > 85%
+
+This alert rule continuously monitors the percentage of open files in an OpenSearch cluster. When the percentage exceeds 85% within the specified timeframe, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose an OpenSearch cluster typically operates with a healthy percentage of open files, but due to increased usage or resource limitations, the percentage of open files exceeds 85%. When this happens, the alert rule checks for instances where the percentage of open files exceeds 85% within the last 10 minutes and triggers a warning.
+
+#### Actions to take
+
+- Review resource usage metrics and system logs to identify any issues contributing to the high percentage of open files
+- Review OpenSearch cluster configuration settings and consider optimizing resource allocation and file management settings to better handle file usage and prevent excessive file opening
+
+### Load average
+
+This alert rule continuously monitors the load average of an OpenSearch cluster and triggers a warning when the load average exceeds a specified threshold (currently when load average is more than 2). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose the average load on the OpenSearch cluster typically remains below 2, but due to increased query loads or resource constraints, the load average spikes above 2. When this happens, the alert rule checks for load average values over the last 30 minutes. Upon detecting the load average anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+-  Review system metrics such as CPU, memory, and disk usage for any source of increased load on the OpenSearch cluster
+- Review and optimize queries or indexing processes that may be contributing to the increased load on the cluster
+- If the increased load is due to resource limitations, consider scaling up resources such as CPU or memory
+
+
+You can [create additional alerts](https://sematext.com/docs/alerts) on any metric.
+
 ## Metrics
 
 Metric Name<br> Key *(Type)* *(Unit)*                                                                             |  Description

--- a/docs/integration/opensearch-integration.md
+++ b/docs/integration/opensearch-integration.md
@@ -134,14 +134,16 @@ Suppose the OpenSearch cluster experiences a sudden increase in activity or data
 
 ### Swap usage
 
-This alert rule continuously monitors swap usage in an OpenSearch environment by tracking the rate of swap input/output operations. When swap usage exceeds the specified threshold, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors swap usage in an OpenSearch environment by tracking the rate of swap input/output operations. When any amount of swap usage is detected, it triggers a warning (WARN priority). This includes even the slightest swap activity, such as reading or writing a single byte to or from swap space.
 
-Suppose the swap usage on a node in the OpenSearch cluster suddenly spikes, indicating potential resource constraints or performance issues. When this happens, the alert rule checks for swap usage over the last 10 minutes. The alert is triggered when the sum of swap input/output operations within the specified timeframe is more than 1 (the threshold value).
+The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose there is some activity detected in the swap usage on a node in the OpenSearch cluster. Despite the relatively small amount of swap activity, the alert rule triggers a warning to prevent any big (and potentially unacceptable) slowdowns in OpenSearch caused by accessing swap memory.
 
 #### Action to take
 
-- Review system resource metrics to identify any spikes or anomalies in CPU, memory, or disk usage that may be contributing to high swap usage
-- Evaluate OpenSearch configuration settings and adjust resource allocations as needed to optimize performance and prevent excessive swap usage
+- Review system resource metrics to identify any spikes or anomalies in CPU, memory, or disk usage that may be contributing to swap usage
+- Evaluate OpenSearch configuration settings and adjust resource allocations as needed to optimize performance and prevent any swap usage
 
 ### Open files > 85%
 

--- a/docs/integration/opensearch-integration.md
+++ b/docs/integration/opensearch-integration.md
@@ -87,9 +87,9 @@ Significant field data usage points to a misconfiguration. Normally, you'd only 
 
 ### Tripped parent circuit breaker
 
-This alert rule continuously monitors the tripping of the parent circuit breaker in an OpenSearch cluster, detecting instances where the circuit breaker has been triggered due to resource constraints or overload. When such instances are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the tripping of the parent circuit breaker in an OpenSearch cluster, detecting instances where the circuit breaker has been triggered usually due to very high memory usage (for real memory, current default is 95% of JVM heap). When such instances are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
-Suppose an OpenSearch cluster experiences a sudden increase in query load or indexing throughput, leading to resource contention and triggering the parent circuit breaker. When this happens, the alert rule checks for instances of the parent circuit breaker being tripped over the last 5 minutes. The alert is triggered as soon as the circuit breaker is tripped at least once within the specified timeframe.
+Suppose an OpenSearch cluster experiences a sudden increase in query load or indexing throughput, leading to very high memory usage and triggering the parent circuit breaker. When this happens, the alert rule checks for instances of the parent circuit breaker being tripped over the last 5 minutes. The alert is triggered as soon as the circuit breaker is tripped at least once within the specified timeframe.
 
 #### Actions to take
 

--- a/docs/integration/opensearch-integration.md
+++ b/docs/integration/opensearch-integration.md
@@ -27,7 +27,7 @@ When the cluster receives a request, it may need to access data from multiple sh
 ![Latency](../images/integrations/opensearch-latency.png)
 
 #### Indexing Rate and Merge Times
-Monitoring the OpenSearch document indexing rate and merge time can help identify anomalies and related problems before they begin to affect the performance of the cluster. Considering these metrics in parallel with the health of each node can provide essential clues to potential problems within the system, or opportunities to optimize performance.
+Monitoring the OpenSearch document indexing rate and merge time can help detect anomalies and related problems before they begin to affect the performance of the cluster. Considering these metrics in parallel with the health of each node can provide essential clues to potential problems within the system, or opportunities to optimize performance.
 
 ![Merged Documents](../images/integrations/opensearch-merged-documents.png)
 
@@ -43,11 +43,11 @@ Finally, high disk reads and writes can indicate a poorly tuned system. Since ac
 
 ## OpenSearch Default Alerts
 
-As soon as you create an OpenSearch App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+As soon as you create an OpenSearch App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will [notify](https://sematext.com/docs/alerts/alert-notifications/) you of important events that may require your attention, as shown below.
 
 ### Node count anomaly
 
-This alert rule continuously monitors the count of nodes in an OpenSearch cluster, checking for anomalies in the number of nodes present within the cluster. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the count of nodes in an OpenSearch cluster, detecting anomalies in the number of nodes present within the cluster. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose an OpenSearch cluster typically maintains a stable number of nodes, but due to various factors such as node failures, scaling activities, or network issues, the node count experiences sudden changes. When this happens, the alert rule checks for anomalies in the count of nodes over the last 90 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
 
@@ -93,12 +93,12 @@ Suppose an OpenSearch cluster experiences a sudden increase in query load or ind
 
 #### Actions to take
 
-- Analyze resource usage metrics for the OpenSearch cluster, including CPU, memory, and disk utilization, to identify the source of the increased load
+- Analyze resource usage metrics for the OpenSearch cluster, including CPU, memory, and disk utilization, to find the source of the increased load
 - Review and optimize search queries or indexing operations that may be contributing to the increased load on the cluster. Consider optimizing query performance, reducing indexing throughput
 
 ### Unassigned shards anomaly
 
-This alert rule continuously monitors the presence of unassigned shards in an OpenSearch cluster, identifying anomalies in the number of unassigned shards over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors the presence of unassigned shards in an OpenSearch cluster, detecting anomalies in the number of unassigned shards over time. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose an OpenSearch cluster typically maintains a low number of unassigned shards, but due to issues such as node failures or disk space constraints, the number of unassigned shards suddenly increases. When this happens, the alert rule checks for anomalies in the number of unassigned shards over the last 30 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
 
@@ -111,7 +111,7 @@ Suppose an OpenSearch cluster typically maintains a low number of unassigned sha
 
 ### Thread pool rejections anomaly
 
-This alert rule continuously monitors thread pool rejections in an OpenSearch environment, identifying anomalies in the rate at which thread pool requests are rejected. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+This alert rule continuously monitors thread pool rejections in an OpenSearch environment, detecting anomalies in the rate at which thread pool requests are rejected. When anomalies are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
 
 Suppose an OpenSearch cluster experiences a sudden increase in thread pool rejections, potentially due to resource limitations or high query loads. When this happens, the alert rule checks for anomalies in thread pool rejections over the last 90 minutes. Upon detecting the anomaly, the alert rule triggers a warning.
 
@@ -142,7 +142,7 @@ Suppose there is some activity detected in the swap usage on a node in the OpenS
 
 #### Action to take
 
-- Review system resource metrics to identify any spikes or anomalies in CPU, memory, or disk usage that may be contributing to swap usage
+- Review system resource metrics to find any spikes or anomalies in CPU, memory, or disk usage that may be contributing to swap usage
 - Evaluate OpenSearch configuration settings and adjust resource allocations as needed to optimize performance and prevent any swap usage
 
 ### Open files > 85%
@@ -153,7 +153,7 @@ Suppose an OpenSearch cluster typically operates with a healthy percentage of op
 
 #### Actions to take
 
-- Review resource usage metrics and system logs to identify any issues contributing to the high percentage of open files
+- Review resource usage metrics and system logs to find any issues contributing to the high percentage of open files
 - Review OpenSearch cluster configuration settings and consider optimizing resource allocation and file management settings to better handle file usage and prevent excessive file opening
 
 ### Load average

--- a/docs/integration/solr-integration.md
+++ b/docs/integration/solr-integration.md
@@ -99,7 +99,7 @@ The Sematext Solr monitoring agent collects the following metrics.
 
 ## Solr Default Alerts
 
-As soon as you create an Elasticsearch App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+As soon as you create an Elasticsearch App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will [notify](https://sematext.com/docs/alerts/alert-notifications/) you of important events that may require your attention, as shown below.
 
 ### Warmup time > 5m
 

--- a/docs/integration/solr-integration.md
+++ b/docs/integration/solr-integration.md
@@ -110,7 +110,10 @@ Suppose a Solr cache is configured to warm up before serving requests, and the t
 #### Actions to take
 
 - Review the warmup process of the Solr cache for any bottlenecks or configuration issues contributing to the extended warmup time
-- Optimize the warmup process by optimizing queries or adjusting cache configuration settings to reduce warmup time
+- Optimize the warmup process by 
+    - Adjusting the autoWarmCount parameter for relevant caches
+    - Verifying the frequency of soft commits (either autoSoftCommit or from the application) to check if they happening too often
+    - Optimizing queries used during warmup or adjusting cache configuration settings to reduce warmup time. This may involve tuning the newSearcher queries
 
 You can [create additional alerts](https://sematext.com/docs/alerts) on any metric.
 

--- a/docs/integration/solr-integration.md
+++ b/docs/integration/solr-integration.md
@@ -97,6 +97,24 @@ The Sematext Solr monitoring agent collects the following metrics.
 
 ![](https://sematext.com/wp-content/uploads/2019/05/d_solr_requests.png)
 
+## Solr Default Alerts
+
+As soon as you create an Elasticsearch App, you will receive a set of default [alert rules](https://sematext.com/docs/guide/alerts-guide/). These pre-configured rules will notify you of important events that may require your attention, as shown below.
+
+### Warmup time > 5m
+
+This alert rule continuously monitors the warmup time of a Solr cache, identifying instances where the warmup time exceeds 5 minutes. When such instances are detected, it triggers a warning (WARN priority). The minimum delay between consecutive alerts triggered by this alert rule is set to 10 minutes.
+
+Suppose a Solr cache is configured to warm up before serving requests, and the typical warmup time is around 3 minutes. However, due to increased data volume or inefficient warmup processes, the warmup time suddenly increases to 7 minutes. When this happens, the alert rule checks for warmup time anomalies over the last 5 minutes. Upon detecting the warmup time anomaly, the alert rule triggers a warning.
+
+#### Actions to take
+
+- Review the warmup process of the Solr cache for any bottlenecks or configuration issues contributing to the extended warmup time
+- Optimize the warmup process by optimizing queries or adjusting cache configuration settings to reduce warmup time
+
+You can [create additional alerts](https://sematext.com/docs/alerts) on any metric.
+
+
 ## Metrics
 
 Metric Name<br> Key *(Type)* *(Unit)*                                                     |  Description


### PR DESCRIPTION
- This PR adds a section for default alert rules in all integrations supporting them.
- Each alert rule contains a description, an example and a list of actions to be taken. 
- Each action is limited to a short description on what the user should do.