### PR TITLE
SC-19984 Rewrite Synthetics UJS examples which used Live Demos

### DIFF
--- a/docs/synthetics/puppeteer-scripts/README.md
+++ b/docs/synthetics/puppeteer-scripts/README.md
@@ -56,7 +56,7 @@ This script navigates to a Shopify based e-commerce website, adds a book to the 
 
 In single-page apps, the page load event happens only during the initial launch. Any navigation across the app does not trigger a new page load/navigation event. The script has to rely on the visibility/availability of elements for the navigation. 
 
-This script launches a single-page app. The elements are loaded asynchronously, so we cannot rely on the navigation event. It waits for a specific element (sign up link) to appear, clicks the element, then waits for sign up form to load and then goes back to the login page. In the whole script, there is only a single page load during the initial launch of the web page. No instances of navigation after the initial launch trigger any page loads.
+This script launches a single-page app. The elements are loaded asynchronously, so we cannot rely on the navigation event. It waits for a specific elements to appear, fills out a search bar, clicks the search button, then waits for the results to appear before taking a screenshot. In the whole script, there is only a single page load during the initial launch of the web page. No instances of navigation after the initial launch trigger any page loads.
 
 
 
@@ -106,6 +106,11 @@ Additionally, it interacts with platform-specific buttons (Phone, Tablet, Watch,
 
 This script will scrape and extract various metrics related to an App listed on the Apple Store.
 The script waits for the reviews elements to appear, and then extracts the App's rating, total reviews, and percentages of 5-star, 4-star, 3-star, 2-star, and 1-star ratings. The extracted values are then defined as custom metrics using the Sematext context.
+
+
+
+### [Track Multiple Page Load Times](./multiple-page-load-times.js)
+This script visits multiple pages and records their individual load times as [custom metrics](../metrics#custom-metrics), which can then be charted using our [dashboards](../../dashboards/index.md). It also uses some custom helper functions which facilitate finding elements on the page using their selectors.
 
 
 

--- a/docs/synthetics/puppeteer-scripts/multiple-page-load-times.js
+++ b/docs/synthetics/puppeteer-scripts/multiple-page-load-times.js
@@ -14,24 +14,26 @@ async function testPage(page, context) {
   context.setMetric('sematextHomePageLoadTime', sematextHomePageLoadTime);
 
   // Hover over dropdown to expand it
-  const DEMO_DROPDOWN_SELECTOR = '[title="See Demos"]';
-  await findAndClickButton(page, DEMO_DROPDOWN_SELECTOR, 'Demo dropdown');
+  const RESOURCES_DROPDOWN_SELECTOR = '[title="Resources"]';
+  await findSelector(page, RESOURCES_DROPDOWN_SELECTOR, 'Resources dropdown');
+  await page.hover(RESOURCES_DROPDOWN_SELECTOR);
+  await page.waitForTimeout(500); // Wait for the dropdown to expand
 
   // Simulate clicking the demo button, but don't actually click because it opens a new tab, copy the link instead
-  const DEMO_SELECTOR = '[title="Interactive Demo"]';
-  await findSelector(page, DEMO_SELECTOR, 'Demo button');
-  const demoUrl = await page.$eval(DEMO_SELECTOR, element => element.getAttribute('href'));
-  console.log('Demo URL:', demoUrl); // https://apps.sematext.com/demo
+  const SYNTHETICS_DOCS_SELECTOR = '[title="Synthetics"]';
+  await findSelector(page, SYNTHETICS_DOCS_SELECTOR, 'Synthetics docs button');
+  const docsUrl = await page.$eval(SYNTHETICS_DOCS_SELECTOR, element => element.getAttribute('href'));
+  console.log('Synthetics docs URL:', docsUrl); // https://sematext.com/docs/synthetics/
   await page.screenshot({ path: '1_homePage.png' });
   
-  // Navigate to the Sematext Cloud demo page and record the page load time
+  // Navigate to the Sematext Cloud docs page and record the page load time
   startTime = new Date();
-  await page.goto(demoUrl, { waitUntil: 'networkidle2' }); // Using networkidle2 to load all the SPA content
+  await page.goto(docsUrl, { waitUntil: 'networkidle2' }); // Using networkidle2 to load all the content
   endTime = new Date();
-  let sematextDemoPageLoadTime = calculateLoadTimeInSeconds(startTime, endTime);
-  console.log('Demo Page Load Time:', sematextDemoPageLoadTime);
-  context.setMetric('sematextDemoPageLoadTime', sematextDemoPageLoadTime);
-  await page.screenshot({ path: '2_demoPage.png' });
+  let sematextDocsPageLoadTime = calculateLoadTimeInSeconds(startTime, endTime);
+  console.log('Docs Page Load Time:', sematextDocsPageLoadTime);
+  context.setMetric('sematextDocsPageLoadTime', sematextDocsPageLoadTime);
+  await page.screenshot({ path: '2_docsPage.png' });
 }
 module.exports = testPage;
 

--- a/docs/synthetics/puppeteer-scripts/single-page-app.js
+++ b/docs/synthetics/puppeteer-scripts/single-page-app.js
@@ -3,24 +3,22 @@ async function testPage(page) {
     await page.setViewport({
         width: 1200,
         height: 800,
-    })
+    });
 
-    // Go to the URL which switches into the demo account and wait for domcontentloaded
-    await page.goto('https://apps.sematext.com/demo', { waitUntil: 'domcontentloaded' });
+    await page.goto('https://www.airbnb.com/');
+    const SEARCH_INPUT_SELECTOR = 'input[id="bigsearch-query-location-input"]';
+    await page.waitForSelector(SEARCH_INPUT_SELECTOR);
+    await page.screenshot({ path: '1_home.png' });
+    await page.type(SEARCH_INPUT_SELECTOR, 'Reykjavik');
+    const SEARCH_BUTTON_SELECTOR = 'button[data-testid="structured-search-input-search-button"]';
+    await page.waitForSelector(SEARCH_BUTTON_SELECTOR);
+    await page.click(SEARCH_BUTTON_SELECTOR);
 
-    const SYNTHETICS_APP_SELECTOR = 'a[href="/ui/synthetics/monitors"]';
-    await page.waitForSelector(SYNTHETICS_APP_SELECTOR);
-    await page.click(SYNTHETICS_APP_SELECTOR);
-
-    // Wait for the locations map to show up, then take a screenshot
-    await page.waitForSelector('[id="locationsMap"]');
-    await page.screenshot({ path: 'synthetics.png' });
-
-    // Ensure the sidebar element for navigating to the Infra page exists, then click it
-    const INFRA_APP_SELECTOR = 'a[href="/ui/infrastructure"]';
-    await page.waitForSelector(INFRA_APP_SELECTOR);
-    await page.click(INFRA_APP_SELECTOR);
-    await page.screenshot({ path: '3_synthetics.png' });
+    // Look for some elements on a page and wait for a second, to load the page before taking a screenshot
+    const CARD_CONTAINER_SELECTOR = '[data-testid="card-container"]';
+    await page.waitForSelector(CARD_CONTAINER_SELECTOR);
+    await page.waitForTimeout(1000);
+    await page.screenshot({ path: '2_search.png' });
 }
 
 module.exports = testPage


### PR DESCRIPTION
Some of our Synthetics Browser monitor UJS examples used our live demos. Since that functionality has been removed, these have been rewritten to keep the examples relevant and up-to-date. I have also tested that these new examples worked fine for multiple runs from all our predefined locations, and added the missing description for the _Multiple Page Load Times_ example to our docs.