### PR TITLE
Add Playwright example scripts and readme

### DIFF
--- a/docs/synthetics/playwright-scripts/README.md
+++ b/docs/synthetics/playwright-scripts/README.md
@@ -61,7 +61,7 @@ We can also use the `waitForURL` function to wait for a specific URL to appear i
 
 ### [Using custom metrics](./custom-metric.js)
 
-Browser monitors allow you to define and collect custom metrics in the script. Custom metrics can be a value from a web page element, any performance metric that is not supported out of the box in Sematext Browser monitor, or any custom measurement (e.g. time to display suggestions in autocomplete) that needs custom logic. Once the measurement is added in the script, you can see its value in run results and chart it in your Dashboards.
+Browser monitors allow you to define and collect custom metrics in the script. Custom metrics can be a value from a web page element, any performance metric that is not supported out of the box in Sematext Browser monitors, or any custom measurement (e.g. time to display suggestions in autocomplete) that needs custom logic. Once the measurement is added in the script, you can see its value in the run results and chart it in your Dashboards.
 
 The script uses the Performance API of the Chrome browser to fetch the JavaScript script duration and heap size metrics, then adds those values as custom metrics using the `context.setMetric(name, value)` API. Note that `context` is defined as the second parameter of the `testPage()` function, so remember to include it in your script.
 

--- a/docs/synthetics/playwright-scripts/README.md
+++ b/docs/synthetics/playwright-scripts/README.md
@@ -1,0 +1,111 @@
+# User Journey Examples
+
+This folder contains some common use-cases to get you started with writing your own scripts.
+
+We have added these as part of our public repository so users can improve these or add their own.
+
+## Examples List
+
+### [Load a web page](./load-web-page.js)
+
+This is a simple example of a browser script that loads a website and takes a screenshot of a page when the navigation is complete. JPEG and PNG formats are supported for screenshot images. Only one screenshot is allowed per script for Pay-As-You-Go and Standard plans, while the Pro plan supports up to three screenshots per script. The `testScript()` function inside of which you write your script gets the Playwright `page` object as a parameter.
+
+
+
+### [Navigate to a specific page](./navigate-specific-page.js)
+
+This script visits a web page, navigates to a specific page and verifies that the title of the page is as expected. The expect available in Playwright can be used for this. When an assertion fails, the script will fail and details of the failure can be seen in the logs.
+
+
+
+### [Search](./open-search-page.js)
+
+This script loads the DuckDuckGo search page, enters a search term, submits the page using the Enter key (simulates key press event) and waits for the results to load. Then it extracts the first item from the search result and verifies the value of the link.
+
+
+
+### [Login](./login-wiki.js)
+
+This script loads the web page, navigates to the login page, fills in the login details and submits the form. After logging in it navigates to the user profile page and verifies the logged-in user name by extracting the value from the page content.
+
+
+
+### [Use Sensitive Data](./use-sensitive-data.js)
+
+This script utilizes our sensitive data protection feature to load possible user secrets such as usernames and passwords. We navigate to our desired page and fill in the form. For sensitive data we use the secret keys instead of the actual credentials. When this script is run, our script manager will automatically replace the secret key with the actual value.
+
+
+
+### [Fetch and use a token](./fetch-use-token.js)
+
+This script demonstrates how to fetch a token from an authentication API, then use that token in a different request to a secure endpoint.
+
+We recommend using our [Sensitive Data](./sensitive-data.js) feature (mentioned in the previous example) to store the passwords and other credentials you use for performing the authentication. 
+
+
+
+### [Shopping Cart](./shopping-cart.js)
+
+This script navigates to an e-commerce website, adds an item to the cart and fills in the form for the checkout process.
+
+
+
+### [Single Page Application](./single-page-app.js)
+
+This script goes to our own app which is a single-page application. It waits for the page to load, then clicks on a button to navigate to a different page. 
+
+Since this is a SPA the elements are loaded asynchronously, so we cannot rely on the navigation event. It waits for a specific elements to appear, and then take screenshots once those specific elements appear. In the whole script, there is only a single page load during the initial launch of the web page. 
+We can also use the `waitForURL` function to wait for a specific URL to appear instead of waiting for specific elements to appear.
+
+
+
+### [Using custom metrics](./custom-metric.js)
+
+Browser monitors allow you to define and collect custom metrics in the script. Custom metrics can be a value from a web page element, any performance metric that is not supported out of the box in Sematext Browser monitor, or any custom measurement (e.g. time to display suggestions in autocomplete) that needs custom logic. Once the measurement is added in the script, you can see its value in run results and chart it in your Dashboards.
+
+The script uses the Performance API of the Chrome browser to fetch the JavaScript script duration and heap size metrics, then adds those values as custom metrics using the `context.setMetric(name, value)` API. Note that `context` is defined as the second parameter of the `testPage()` function, so remember to include it in your script.
+
+
+
+### [Defining custom metrics from JSON](./custom-metric-json.js)
+
+Custom metrics can also be collected from sources other than CDP. In this example, a JSON response is grabbed from an API response and used to define custom metrics. Like in the previous example, custom metrics defined this way can be used as data sources for charts. With custom metrics you can do a lot more than just monitor performance, such as keeping an eye out if it'll be rainy tomorrow from some weather report API and sending yourself an alert, or charting the number of users on the various services you offer over time to analyze trends.
+
+This example showcases invoking an endpoint which provides information about currency exchange rates, then defining custom metrics based on those values. These could then be used as a basis for charts, and alerts could be created if these exchange rates reach a certain point.
+
+
+
+### [Request interception](./request-interception.js)
+
+This script utilizes Playwright's route feature to intercept and then block any URLs containing a string from a pre-defined list. If a requested URL contains any of these strings, the request will be blocked and logged.
+
+
+
+### [Text search](./text-search.js)
+
+This script navigates to a web page, searches for a specific text and throws an error if the text is not found.
+
+
+
+### [Extract Google Play Store metrics](./google-play.js)
+
+This script will scrape and extract various metrics related to an App listed on the Google Play Store.
+The script navigates through the App's store page, capturing and processing data such as overall ratings, the number of reviews, and the number of downloads.
+
+
+
+### [Extract Apple Store metrics](./apple-store.js)
+
+This script will scrape and extract various metrics related to an App listed on the Apple Store.
+The script waits for the reviews elements to appear, and then extracts the App's rating, total reviews, and percentages of 5-star, 4-star, 3-star, 2-star, and 1-star ratings. The extracted values are then defined as custom metrics using the Sematext context.
+
+
+
+### [Track Multiple Page Load Times](./multiple-page-load-times.js)
+This script visits multiple pages and records their individual load times as [custom metrics](../metrics#custom-metrics), which can then be charted using our [dashboards](../../dashboards/index.md). 
+
+
+
+### [Multiple Browser Tabs](./multi-tab.js)
+
+This script launches and interacts with multiple browser tabs. It first navigates to a specified URL and waits for it to load. Once loaded it then opens a link in the page in a new browser tab. It then gets the new tab and captures a screenshot.

--- a/docs/synthetics/playwright-scripts/apple-store.js
+++ b/docs/synthetics/playwright-scripts/apple-store.js
@@ -1,0 +1,55 @@
+export default async function testPage(page, context) {
+  // App Store URL, in this example WhatsApp is used.
+  const baseUrl = "https://apps.apple.com/us/app/whatsapp-messenger/id310633997";
+  
+  // Goto the URL
+  await page.goto(baseUrl);
+
+  // Take screenshot of the page for reference
+  await page.screenshot({ path: 'screenshot.jpg' });
+
+  // Extract ratings information
+  const rating = parseFloat(await page.locator('.we-customer-ratings__averages__display').innerText());
+  const reviewsText = await page.locator('.we-customer-ratings__count').locator('visible=true').innerText();
+  const reviews = parseInt(reviewsText.replace(" Ratings", ""));
+
+  
+  const starPercentages = [];
+  for (const bar of await page.locator('.we-star-bar-graph__bar__foreground-bar').all()) {
+    const widthStyle = await bar.getAttribute('style');
+    const widthPercentage = parseInt(widthStyle.replace('width:', '').replace('%', '').replace(';', '').trim());
+    starPercentages.push(widthPercentage);
+  };
+
+  
+  // Set a custom metric for the App rating
+  context.setMetric('appstore.rating', rating);
+
+  // Set a custom metric for the number of App reviews
+  context.setMetric('appstore.reviews', reviews);
+
+  // Set a custom metric for the number of 5* ratings
+  context.setMetric('appstore.ratings.fivestar', starPercentages[0]);
+
+  // Set a custom metric for the number of 4* ratings
+  context.setMetric('appstore.ratings.fourstar', starPercentages[1]);
+
+  // Set a custom metric for the number of 3* ratings
+  context.setMetric('appstore.ratings.threestar', starPercentages[2]);
+
+  // Set a custom metric for the number of 2* ratings
+  context.setMetric('appstore.ratings.twostar', starPercentages[3]);
+
+  // Set a custom metric for the number of 1* ratings
+  context.setMetric('appstore.ratings.onestar', starPercentages[4]);
+
+  console.log('Rating:', rating);
+  console.log('Reviews:', reviews);
+  console.log('=== Percentage of Reviews ===')
+  console.log('5 Star:', starPercentages[0]);
+  console.log('4 Star:', starPercentages[1]);
+  console.log('3 Star:', starPercentages[2]);
+  console.log('2 Star:', starPercentages[3]);
+  console.log('1 Star:', starPercentages[4]);
+
+}

--- a/docs/synthetics/playwright-scripts/basic-ntlm-authentication.js
+++ b/docs/synthetics/playwright-scripts/basic-ntlm-authentication.js
@@ -1,0 +1,18 @@
+// This script uses Playwright to authenticate and take a screenshot of the page
+export default async function testPage(page) {
+  // Create a new browser context with HTTP credentials
+  const browser = page.context().browser();
+  const browserContext = await browser.newContext({
+    httpCredentials: {
+      username: 'user',
+      password: 'pass'
+    }
+  });
+  
+  // Override the page by creating a new page in the new context
+  page = await browserContext.newPage();
+  await page.goto('https://authenticationtest.com/HTTPAuth/');
+
+  // take a screenshot
+  await page.screenshot({ path: 'screenshot.jpg' });
+}

--- a/docs/synthetics/playwright-scripts/custom-metric-json.js
+++ b/docs/synthetics/playwright-scripts/custom-metric-json.js
@@ -1,0 +1,19 @@
+// This script gets the exchange rates of various currencies and defines the results as custom metrics
+export default async function testPage(page, context) {
+    const response = await page.goto("https://api.frankfurter.app/latest?from=EUR");
+    const bodyJSON = await response.json();
+
+    // Extract the values from the response JSON and define them as custom metrics
+    const USD = bodyJSON.rates.USD;
+    const AUD = bodyJSON.rates.AUD;
+    const CNY = bodyJSON.rates.CNY;
+    // Metric names should be alphanumeric, otherwise they will be ignored
+    context.setMetric('currency.EUR_USD', USD);
+    context.setMetric('currency.EUR_AUD', AUD);
+    context.setMetric('currency.EUR_CNY', CNY);
+
+    // Log out the values at the start to make sure you're getting the metrics
+    console.log(USD);
+    console.log(AUD);
+    console.log(CNY);
+}

--- a/docs/synthetics/playwright-scripts/custom-metric.js
+++ b/docs/synthetics/playwright-scripts/custom-metric.js
@@ -1,0 +1,21 @@
+export default async function testPage(page, context) {
+  // Create a Chrome DevTools Protocol (CDP) session and start measuring performance metrics
+  const client = await page.context().newCDPSession(page);
+  await client.send('Performance.enable');
+  await page.goto('https://youtube.com/');
+
+  // Fetch all the performance metrics and choose the ones we want
+  const performanceMetrics = await client.send('Performance.getMetrics');
+  const scriptDuration = performanceMetrics.metrics.find((x) => x.name === 'ScriptDuration').value;
+  const usedHeap = performanceMetrics.metrics.find((x) => x.name === 'JSHeapUsedSize').value;
+
+  // Define the chosen metrics as custom metrics in Sematext Synthetics
+  // Metric names should be unique for this Synthetics App
+  // Metric names should be alphanumeric, otherwise they will be ignored
+  context.setMetric('heap.size', usedHeap);
+  context.setMetric('script.time', scriptDuration);
+
+  // Log out the values at the start to make sure you're getting the metrics
+  console.log(usedHeap);
+  console.log(scriptDuration);
+}

--- a/docs/synthetics/playwright-scripts/fetch-use-token.js
+++ b/docs/synthetics/playwright-scripts/fetch-use-token.js
@@ -1,0 +1,42 @@
+export default async function testPage(page) {
+
+    // Get the api request API to make our post call
+    const apiRequest = page.request;
+
+    // Make a POST request to the authentication endpoint
+    const response = await apiRequest.post("https://private-c82e7-stcloudtest.apiary-mock.com/authenticate", {
+        data: {
+            username: "exampleUser",
+            password: "examplePassword"
+        }
+    });
+
+    const responseJSON = await response.json();
+
+    // Secure URL which requires authentication and the appropriate headers which we'll add to the request
+    const secureURL = `https://private-c82e7-stcloudtest.apiary-mock.com/${responseJSON.loginPath}`;
+    const additionalHeaders = {
+        "content-type": "application/json",
+        "Authorization": `Bearer ${responseJSON.token}`
+    };
+
+    // Intercept the request to the secure URL and add the necessary headers
+    await page.route(secureURL, route => {
+        route.continue({
+            method: 'POST',
+            headers: {
+                ...route.request().headers(),
+                ...additionalHeaders
+            }
+        });
+    });
+
+    // Now safely navigate to the secure URL
+    const result = await page.goto(secureURL);
+
+    console.log({
+        url: result.url(),
+        statusCode: result.status(),
+        body: await result.text()
+    });
+}

--- a/docs/synthetics/playwright-scripts/google-play.js
+++ b/docs/synthetics/playwright-scripts/google-play.js
@@ -1,0 +1,57 @@
+// This script extracts a Google Play Store App's ratings as custom metrics.
+
+export default async function testPage(page, context) {
+
+
+  // Goto the WhatsappURL
+  await page.goto('https://play.google.com/store/apps/details?id=com.whatsapp');
+  
+  // Create a function in the page context to extract numerical values
+  const convertToNumber = (input) => {
+    const multiplier = {
+      'B': 1000000000,
+      'M': 1000000,
+      'K': 1000,
+    };
+    const match = input.match(/^(\d+(\.\d+)?)\s*([BKM])?.*$/);
+    if (!match) {
+      throw new Error('Invalid input format');
+    }
+    const value = parseFloat(match[1]);
+    const suffix = match[3].charAt(0).toUpperCase();
+    return multiplier[suffix] ? value * multiplier[suffix] : value;
+  };
+  
+  
+  // Take screenshot of the page for reference
+  await page.screenshot({ path: 'screenshot.jpg' });
+  const starRatingElement = page.locator('[itemprop="starRating"]').first();
+  const starRating = await starRatingElement.locator('div[aria-label$="stars out of five stars"]').textContent();
+  const rating = parseFloat(starRating?.replace(/[^\d.]/g, ''));
+  console.log('Rating: ', rating);
+
+
+  
+  // Extract Number of Reviews
+  const starRatingParentElement = await starRatingElement.evaluateHandle(element => element.parentElement.parentElement);
+  const numberOfReviewsElement = await starRatingParentElement.waitForSelector('div:nth-child(2)');
+  const numberOfReviews = convertToNumber(await numberOfReviewsElement.textContent());
+  console.log('Number of Reviews: ', numberOfReviews)
+  
+  // Extract Number of Downloads
+
+  const downloadsText = await page.getByText('Downloads')
+  .first()
+  .evaluate(element => element.previousElementSibling?.textContent);
+  const numberOfDownloads = convertToNumber(downloadsText);
+  console.log('Number of Downloads: ', numberOfDownloads);
+
+  // Set a custom metric for the App rating
+  context.setMetric('playstore.rating', parseFloat(rating));
+
+  // Set a custom metric for the number of App reviews
+  context.setMetric('playstore.reviews', numberOfReviews);
+  
+  // Set a custom metric for the number of App downloads
+  context.setMetric('playstore.downloads', numberOfDownloads);
+}

--- a/docs/synthetics/playwright-scripts/google-play.js
+++ b/docs/synthetics/playwright-scripts/google-play.js
@@ -3,7 +3,7 @@
 export default async function testPage(page, context) {
 
 
-  // Goto the WhatsappURL
+  // Navigate to the Whatsapp URL
   await page.goto('https://play.google.com/store/apps/details?id=com.whatsapp');
   
   // Create a function in the page context to extract numerical values

--- a/docs/synthetics/playwright-scripts/load-web-page.js
+++ b/docs/synthetics/playwright-scripts/load-web-page.js
@@ -1,0 +1,6 @@
+export default async function testPage(page) {
+    // visit the home page
+    await page.goto('https://www.apple.com/');
+    // take screenshot of the home page
+    await page.screenshot({ path: 'screenshot.jpg' });
+}

--- a/docs/synthetics/playwright-scripts/login-wiki.js
+++ b/docs/synthetics/playwright-scripts/login-wiki.js
@@ -1,0 +1,17 @@
+import { expect } from '@playwright/test';
+
+export default async function testPage(page) {
+    // Navigate to wikipedia
+    await page.goto('https://en.wikipedia.org/');
+    await page.locator('#pt-login-2').click();
+    const userName = 'Sematext-wiki';
+    // Fill in the username and password then login
+    await page.locator('#wpName1').fill(userName);
+    await page.locator('#wpPassword1').fill('semapassword');
+    await page.locator('#wpLoginAttempt').click();
+    // Click on the user page
+    await page.locator('#pt-userpage-2').click();
+    const userNameFromPage = await page.locator('#firstHeading').textContent();
+    // Match username against the one used to login
+    expect(userNameFromPage.split(',')[1].toLowerCase()).toContain(userName.toLowerCase());
+}

--- a/docs/synthetics/playwright-scripts/multi-tab.js
+++ b/docs/synthetics/playwright-scripts/multi-tab.js
@@ -1,0 +1,19 @@
+export default async function testPage(page) {
+  // Navigate to w3schools.com and take a screenshot
+  await page.goto('https://www.w3schools.com/', { waitUntil: 'domcontentloaded' });
+  await page.screenshot({ path: 'firstTab.png' });
+
+  // Get browser context to listen for new page
+  const browserContext = page.context();
+
+  // Get new tab that is opened after link is clicked
+  const [newPage] = await Promise.all([
+    browserContext.waitForEvent('page'),
+    page.getByRole('link', { name: 'W3Schools Certificates' }).click()
+  ]);
+
+  // Wait for the new page to load and take a screenshot
+  await newPage.waitForLoadState('domcontentloaded');
+  await newPage.screenshot({ path: 'secondTab.png' });
+
+}

--- a/docs/synthetics/playwright-scripts/multiple-page-load-times.js
+++ b/docs/synthetics/playwright-scripts/multiple-page-load-times.js
@@ -1,0 +1,29 @@
+// This script loads multiple pages and records their individual page load times as custom metrics
+export default async function testPage(page, context) {
+  // Helper function to calculate the load time in seconds
+  const calculateLoadTimeInSeconds = (startTime, endTime) =>
+    Number(((endTime.getTime() - startTime.getTime()) / 1000).toFixed(2));
+
+  // Go to the W3school homepage and record the page load time
+  let startTime = new Date();
+  await page.goto("https://www.w3schools.com/");
+  let endTime = new Date();
+  let firstPageLoadTime = calculateLoadTimeInSeconds(startTime, endTime);
+  console.log('Home Page Load Time:', firstPageLoadTime);
+  context.setMetric('firstPageLoadTime', firstPageLoadTime);
+
+  const browserContext = page.context();
+
+  const [newPage] = await Promise.all([
+    browserContext.waitForEvent('page'),
+    page.getByRole('link', { name: 'W3Schools Certificates' }).click()
+  ]);
+  startTime = new Date();
+  // Wait for the new page to load
+  await newPage.waitForLoadState();
+  endTime = new Date();
+  let pageLoadTime = calculateLoadTimeInSeconds(startTime, endTime);
+  console.log('Demo Page Load Time:', pageLoadTime);
+  context.setMetric('pageLoadTime', pageLoadTime);
+  await newPage.screenshot({ path: '2_tab.png' })
+}

--- a/docs/synthetics/playwright-scripts/navigate-specific-page.js
+++ b/docs/synthetics/playwright-scripts/navigate-specific-page.js
@@ -1,0 +1,15 @@
+import { expect } from '@playwright/test';
+
+export default async function testPage(page) {
+  
+  // Visit the home page
+  await page.goto('https://www.apple.com/');
+
+  // Click on the Mac link
+  await page.getByLabel('Mac', { exact: true }).click();
+  await page.waitForURL('https://www.apple.com/mac/');
+
+  // Get the h1 element text and verify it is 'Mac'
+  const h1 = await page.locator('h1').textContent();
+  expect(h1).toBe('Mac')
+}

--- a/docs/synthetics/playwright-scripts/open-search-page.js
+++ b/docs/synthetics/playwright-scripts/open-search-page.js
@@ -1,0 +1,9 @@
+import { expect } from '@playwright/test';
+
+export default async function testPage(page) {
+    await page.goto('https://duckduckgo.com/');
+    await page.getByLabel('Search with DuckDuckGo').fill('google');
+    await page.getByLabel('Search', { exact: true }).click();
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('a[href="https://www.google.com/"]').first()).toBeAttached();
+}

--- a/docs/synthetics/playwright-scripts/request-interception.js
+++ b/docs/synthetics/playwright-scripts/request-interception.js
@@ -1,0 +1,20 @@
+// Block requests to certain URLs
+const blockList = [
+    'google-analytics',
+    'googleadservices.com',
+    'googlesyndication',
+];
+
+// This script uses Playwright to block requests to certain URLs and take a screenshot of the page
+export default async function testPage(page) {
+    await page.route('**/*', (route) => {
+        if (blockList.some(resource => route.request().url().includes(resource))) {
+            // Remove this log statement once you verify that the requests are being blocked
+            console.log("Blocked:", route.request().url());
+            route.abort();
+        }
+        else route.continue();
+    });
+    await page.goto('https://sematext.com/');
+    await page.screenshot({ path: 'screenshot.jpg' });
+}

--- a/docs/synthetics/playwright-scripts/shopping-cart.js
+++ b/docs/synthetics/playwright-scripts/shopping-cart.js
@@ -1,0 +1,39 @@
+import { expect } from '@playwright/test';
+
+export default async function testPage(page) {
+  await page.goto('https://www.saucedemo.com/');
+
+  // Set the screen resolution, as things render differently on different screen widths
+  await page.setViewportSize({
+    width: 1200,
+    height: 800,
+  });
+
+  // Login
+  await page.locator('#user-name').fill('standard_user');
+  await page.locator('#password').fill('secret_sauce');
+  await page.locator('data-test=login-button').click();
+  
+  // Go to item and add to cart
+  await page.getByText('Sauce Labs Backpack').click();
+  await page.getByText('ADD TO CART').click();
+
+  // Go to cart
+  await page.locator('data-test=shopping-cart-link').click();
+  await page.getByText('Checkout').click();
+
+  // Fill out form
+  await page.locator('#first-name').fill('John');
+  await page.locator('#last-name').fill('Doe');
+  await page.locator('#postal-code').fill('12345');
+  await page.getByText('Continue').click();
+
+  // Confirm page has the expected content
+  await expect(page.locator('data-test=inventory-item')).toContainText('Sauce Labs Backpack');
+  await page.getByText('Finish').click();
+
+  // Confirm order
+  await expect(page.locator('body')).toContainText('Thank you for your order!');
+
+  await page.screenshot({ path: 'shoppingCart.jpg' });
+}

--- a/docs/synthetics/playwright-scripts/single-page-app.js
+++ b/docs/synthetics/playwright-scripts/single-page-app.js
@@ -1,0 +1,22 @@
+export default async function testPage(page) {
+    // Set the screen resolution, as things render differently on different screen widths
+    await page.setViewportSize({
+        width: 1200,
+        height: 800,
+    })
+
+    // Go to the URL which switches into the demo account and wait for domcontentloaded
+    await page.goto('https://apps.sematext.com/demo', { waitUntil: 'domcontentloaded' });
+
+
+    // Go to the Synthetics page
+    await page.getByRole('link').filter({ hasText: 'Synthetics' }).click();
+    // Wait for the locations map to show up, then take a screenshot
+    await page.locator('[id="locationsMap"]').waitFor();
+    await page.screenshot({ path: 'synthetics.png' });
+
+    // We use more specific selectors to get our link element
+    await page.getByRole('listitem').and(page.getByTitle('Logs')).getByRole('link').click();
+    await page.getByText('Custom Logs Demo').waitFor();
+    await page.screenshot({ path: 'Logs.png' });
+}

--- a/docs/synthetics/playwright-scripts/text-search.js
+++ b/docs/synthetics/playwright-scripts/text-search.js
@@ -1,0 +1,5 @@
+export default async function testPage(page) {
+    await page.goto('https://sematext.com/');
+    await page.getByText('Sematext provides Monitoring & Alerting').isVisible();
+    await page.screenshot({ path: 'screenshot.jpg' });
+}

--- a/docs/synthetics/playwright-scripts/text-search.js
+++ b/docs/synthetics/playwright-scripts/text-search.js
@@ -1,5 +1,7 @@
+import { expect } from '@playwright/test';
+
 export default async function testPage(page) {
     await page.goto('https://sematext.com/');
-    await page.getByText('Sematext provides Monitoring & Alerting').isVisible();
+    await expect(page.getByText('Sematext provides Monitoring & Alerting')).toBeVisible();
     await page.screenshot({ path: 'screenshot.jpg' });
 }

--- a/docs/synthetics/playwright-scripts/use-sensitive-data.js
+++ b/docs/synthetics/playwright-scripts/use-sensitive-data.js
@@ -1,0 +1,12 @@
+import { expect } from '@playwright/test';
+
+export default async function testPage(page) {
+    await page.goto('https://www.saucedemo.com/');
+
+    // Uses Secret Keys instead of actual credentials
+    await page.locator('#user-name').fill('$__username__');
+    await page.locator('#password').fill('$__password__');
+    await page.locator('data-test=login-button').click();
+    await expect(page.locator('body')).toContainText('Products');
+    await page.screenshot({ path: 'screenshot.jpg' });
+}


### PR DESCRIPTION
I create a folder similar to Puppeteer scripts and added all the scripts with Puppeteer replacing by Playwright. I have tested all these scripts again so you don't have to do that at all. If you want to review the scripts its better to just review their comments or some usage.

The Readme file for most parts is the same as before with reference to Puppeteer removed and minor changes based on the script changes I made.