### PR TITLE
ful_NO-JIRA-fix-infra-link

### DIFF
--- a/docs/integration/docker.md
+++ b/docs/integration/docker.md
@@ -1,4 +1,4 @@
 title: Docker Monitoring Integration
 description: Container performance monitoring - metrics, event, log collection and parsing for Docker
 
-Docker integration has been retired in favor of [Infra integration](./infra) which covers monitoring of bare metal servers, virtual machines and containers. 
+Docker integration has been retired in favor of [Infra integration](https://sematext.com/docs/integration/infra/) which covers monitoring of bare metal servers, virtual machines and containers. 


### PR DESCRIPTION
@cpipilas the link is broken, redirects to https://sematext.com/docs/integration/docker/infra
I updated to https://sematext.com/docs/integration/infra/.

I cannot deploy this fix till Matija is back, so you can approve the new link till then.