### PR TITLE
[SC-21995] feat(sematext-agent): change version to `latest-{major}`

### DIFF
--- a/docs/agents/sematext-agent/autodisco/removing-stale-resources.md
+++ b/docs/agents/sematext-agent/autodisco/removing-stale-resources.md
@@ -9,7 +9,7 @@ In Kubernetes deployments, Sematext Agent will make sure to remove any lingering
 You have to run the following command on your Docker hosts:
 
 ```bash
-sudo docker ps -q -f "ancestor=sematext/app-agent:latest-3" | xargs  docker rm -f
+sudo docker ps -q -f "ancestor=sematext/app-agent:latest" | xargs  docker rm -f
 ```
 
 

--- a/docs/agents/sematext-agent/autodisco/removing-stale-resources.md
+++ b/docs/agents/sematext-agent/autodisco/removing-stale-resources.md
@@ -9,7 +9,7 @@ In Kubernetes deployments, Sematext Agent will make sure to remove any lingering
 You have to run the following command on your Docker hosts:
 
 ```bash
-sudo docker ps -q -f "ancestor=sematext/app-agent:latest" | xargs  docker rm -f
+sudo docker ps -q -f "ancestor=sematext/app-agent:latest-3" | xargs  docker rm -f
 ```
 
 

--- a/docs/agents/sematext-agent/autodisco/resource-limits.md
+++ b/docs/agents/sematext-agent/autodisco/resource-limits.md
@@ -32,7 +32,7 @@ docker run ... \
 ... \
 -e AUTODISCO_AGENT_CONTAINER_MEM_LIMIT=1024 \ # Override default memory limit to 1024Mi
 -e AUTODISCO_AGENT_CONTAINER_CPU_SET=0-3 \ # Assign CPU cores 0-3 to the container
-sematext/agent:latest
+sematext/agent:latest-3
 ```
 
 By using these environment variables, you can fine-tune the resource allocation for non-Kubernetes containers based on your specific requirements.

--- a/docs/agents/sematext-agent/containers/configuration.md
+++ b/docs/agents/sematext-agent/containers/configuration.md
@@ -79,7 +79,7 @@ docker run -d --restart always --privileged -P --name st-agent --memory 512MB \
 -e LOGS_RECEIVER_URL=https://logsene-receiver.sematext.com \
 -e EVENTS_RECEIVER_URL=https://event-receiver.sematext.com \
 -e COMMAND_SERVER_URL=https://command.sematext.com \
-sematext/agent:latest
+sematext/agent:latest-3
 ```
 
 You can add different environment variables preceded by the `-e` argument. For example, if you want to ignore the discovery of `nginx` processes, add `-e CONTAINER_SKIP_BY_IMAGE=nginx`. Remember to place the last `\` right after:
@@ -100,7 +100,7 @@ docker run -d --restart always --privileged -P --name st-agent --memory 512MB \
 -e EVENTS_RECEIVER_URL=https://event-receiver.sematext.com \
 -e COMMAND_SERVER_URL=https://command.sematext.com \
 -e CONTAINER_SKIP_BY_IMAGE=nginx \
-sematext/agent:latest
+sematext/agent:latest-3
 ```
 
 To skip multiple images simply separate them with a comma. In the example below we ignore containers whose names contain `nginx` or `httpd`.
@@ -111,7 +111,7 @@ docker run -d --restart always --privileged -P --name st-agent --memory 512MB \
 -v /sys/:/hostfs/sys:ro \
 # ...
 -e CONTAINER_SKIP_BY_IMAGE=nginx,apache/httpd \
-sematext/agent:latest
+sematext/agent:latest-3
 ```
 
 **Note:** The `CONTAINER_SKIP_BY_IMAGE` values will search for any substring match among the discovered images. Therefore, if you wish to skip the `apache/httpd` image, you can simply use `httpd`. This applies similarly to other matching and skipping options such as `CONTAINER_MATCH_BY_IMAGE`, `CONTAINER_MATCH_BY_NAME`, and `CONTAINER_SKIP_BY_NAME`.
@@ -123,7 +123,7 @@ If you are using Docker Swarm, append the new line in the `environment` section 
 version: "3"
 services:
   st-agent:
-    image: sematext/agent:latest
+    image: sematext/agent:latest-3
     privileged: true
     environment:
       - INFRA_TOKEN=<your-infra-token>

--- a/docs/agents/sematext-agent/containers/installation.md
+++ b/docs/agents/sematext-agent/containers/installation.md
@@ -17,7 +17,7 @@ docker run -d  --restart always --privileged -P --name st-agent \
 -v /etc/group:/etc/group:ro \
 -e INFRA_TOKEN=<YOUR_INFRA_APP_TOKEN_HERE> \
 -e REGION=<US or EU> \
-sematext/agent:latest
+sematext/agent:latest-3
 ```
 
 _[Read more](/docs/agents/sematext-agent/permission-requirements/#bind-mounts) about why Sematext Agent needs access to host files and directories._
@@ -33,7 +33,7 @@ By default, the US region receiver endpoints are used to ship data to Sematext C
 To update or upgrade the Sematext Agent to the latest version, you can pull the latest image and recreate the container:
 
 ```bash
-docker pull sematext/agent:latest
+docker pull sematext/agent:latest-3
 docker rm -f st-agent
 docker run -d  --restart always --privileged -P --name st-agent \
 -v /:/hostfs:ro \
@@ -44,7 +44,7 @@ docker run -d  --restart always --privileged -P --name st-agent \
 -v /etc/group:/etc/group:ro \
 -e INFRA_TOKEN=<YOUR_INFRA_APP_TOKEN_HERE> \
 -e REGION=<US or EU> \
-sematext/agent:latest
+sematext/agent:latest-3
 ```
 
 ### Uninstalling Sematext Agent on Docker
@@ -72,7 +72,7 @@ docker run -d  --restart always --privileged -P --name st-agent \
 -v /var/run/docker.sock:/var/run/docker.sock:ro \
 -e INFRA_TOKEN=<YOUR_INFRA_APP_TOKEN_HERE> \
 -e REGION=<US or EU> \
-sematext/agent:latest
+sematext/agent:latest-3
 ```
 
 Docker on OSX relies on virtualization capabilities to spawn the containers inside the VM. The side effect is that Sematext Agent will report the OS metrics of the VM box and not the bare-metal machine where OSX is running.
@@ -82,7 +82,7 @@ Docker on OSX relies on virtualization capabilities to spawn the containers insi
 To update the Sematext Agent on Docker for OSX, follow the same steps as for Docker:
 
 ```bash
-docker pull sematext/agent:latest
+docker pull sematext/agent:latest-3
 docker rm -f st-agent
 docker run -d  --restart always --privileged -P --name st-agent \
 -v /:/hostfs:ro \
@@ -94,7 +94,7 @@ docker run -d  --restart always --privileged -P --name st-agent \
 -v /var/run/docker.sock:/var/run/docker.sock:ro \
 -e INFRA_TOKEN=<YOUR_INFRA_APP_TOKEN_HERE> \
 -e REGION=<US or EU> \
-sematext/agent:latest
+sematext/agent:latest-3
 ```
 
 ### Uninstalling Sematext Agent on Docker for OSX
@@ -120,7 +120,7 @@ $ docker run -d  --restart always --privileged -P --name st-agent \
 -v /dev:/hostfs/dev:ro \
 -e INFRA_TOKEN=<YOUR_INFRA_APP_TOKEN_HERE> \
 -e REGION=<US or EU> \
-sematext/agent:latest
+sematext/agent:latest-3
 ```
 
 ## Docker Compose
@@ -132,7 +132,7 @@ For the deployments that are orchestrated by Docker Compose, you can use the fol
 version: '3'
 services:
   sematext-agent:
-    image: 'sematext/agent:latest'
+    image: 'sematext/agent:latest-3'
     environment:
       - affinity:container!=*sematext-agent*
       - INFRA_TOKEN=<YOUR_INFRA_APP_TOKEN_HERE>
@@ -188,7 +188,7 @@ The following `docker-compose.yml` file provides a working configuration that ca
 version: '3'
 services:
   sematext-agent:
-    image: 'sematext/agent:latest'
+    image: 'sematext/agent:latest-3'
     environment:
       - INFRA_TOKEN: <YOUR_INFRA_APP_TOKEN_HERE>
       - REGION: <US or EU>
@@ -225,7 +225,7 @@ _[Read more](/docs/agents/sematext-agent/permission-requirements/#bind-mounts) a
 To update the Sematext Agent on Docker Swarm, follow these steps:
 
 ```bash
-docker service update --image sematext/agent:latest sematext-agent
+docker service update --image sematext/agent:latest-3 sematext-agent
 ```
 
 This command will update the Sematext Agent service to the latest image.

--- a/docs/agents/sematext-agent/kubernetes/installation.md
+++ b/docs/agents/sematext-agent/kubernetes/installation.md
@@ -212,7 +212,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: agent
-        image: sematext/agent:latest
+        image: sematext/agent:latest-3
         imagePullPolicy: Always
         env:
         - name: AUTODISCO_VECTOR_SERVICE_ACCOUNT
@@ -300,7 +300,7 @@ To update the Sematext Agent when installed manually, you need to modify the Dae
 
 ```yaml
     - name: agent
-      image: sematext/agent:latest
+      image: sematext/agent:latest-3
 ```
 
 2. **Apply the updated DaemonSet:**

--- a/docs/monitoring/spm-faq.md
+++ b/docs/monitoring/spm-faq.md
@@ -443,7 +443,7 @@ docker run -d  --restart always --memory 168m --memory-swap=236m --privileged -P
   -v /etc/group:/etc/group:ro \
   -e INFRA_TOKEN=<your-infra-token> \
   -e REGION=US \
-  sematext/agent:latest
+  sematext/agent:latest-3
 ```
 
 ### What's the CPU usage overhead for Sematext Agent running in a container?


### PR DESCRIPTION
Update Sematext Agent Docker image version from `latest` to `latest-3` across all deployment configurations.

This change addresses version aliasing issues by using a major version-specific latest tag instead of the generic `latest` tag. The update ensures consistent agent versioning across different deployment methods and environments.