### PR TITLE
SC-24946 Add AI-powered OpenTelemetry onboarding guide + callouts

### DIFF
--- a/docs/agents/sematext-agent/opentelemetry/index.md
+++ b/docs/agents/sematext-agent/opentelemetry/index.md
@@ -7,6 +7,9 @@ The Sematext Agent includes built-in OpenTelemetry support, acting as a local co
 
 OpenTelemetry support is available starting from version [3.10.0](https://sematext.com/docs/agents/sematext-agent/releasenotes/#version-3100).
 
+!!! tip "Using an AI coding agent?"
+    Load the [sematext-otel skill](/docs/guide/ai-powered-otel-onboarding/) into [Claude Code](https://docs.claude.com/en/docs/claude-code) (or any agent that can read a markdown URL) and it will walk you through both the agent-based flow described here and the managed-OTLP-endpoint alternative, producing the exact env-var block for your language and deployment.
+
 > **Note**: While this guide focuses on tracing configuration, the agent also supports OpenTelemetry metrics and logs, with full documentation for those coming soon.
 
 ## Architecture Overview

--- a/docs/guide/ai-powered-otel-onboarding.md
+++ b/docs/guide/ai-powered-otel-onboarding.md
@@ -1,0 +1,56 @@
+title: AI-Powered OpenTelemetry Onboarding
+description: Use an AI coding agent like Claude Code to instrument your applications with OpenTelemetry and ship telemetry to Sematext Cloud, guided by an open-source skill.
+
+Instrumenting an application with OpenTelemetry has a lot of moving parts — which SDK, which auto-instrumentation package, which endpoint and protocol, which auth header, which signals you actually want to ship. None of it is hard, but all of it is fiddly. Multiply by every service in your stack and the time adds up.
+
+Sematext publishes an open-source [Agent Skill](https://github.com/sematext/sematext-otel-onboarding/blob/main/skills/sematext-otel.md) that walks you through the decisions and assembles the exact configuration for your situation. Load it into [Claude Code](https://docs.claude.com/en/docs/claude-code) (or any AI agent that can read a markdown URL) and answer six short questions; it produces the env-var block ready to paste plus a pointer to a runnable reference example in the [sematext-otel-onboarding](https://github.com/sematext/sematext-otel-onboarding) repo.
+
+## What the skill does
+
+When loaded by an agent, the skill triages your setup through six questions:
+
+1. **Region** — US or EU. Determines which OTLP endpoint to use; tokens are region-bound.
+2. **App types** — Tracing, Logs, Monitoring. Any combination. Each App has its own token; the skill only configures signals you're actually wiring up.
+3. **Flow** — Sematext managed OTLP endpoint, or the Sematext Agent acting as a local OTLP collector.
+4. **Protocol** — HTTP (default, `http/protobuf`) or gRPC.
+5. **Language and environment** — Java/Spring Boot, Node.js/Express, Python/Flask, .NET/ASP.NET Core, PHP/Laravel, across baremetal, Docker, or Kubernetes.
+6. **Auto or manual instrumentation** — auto covers traces and metrics with no code changes; manual additionally covers logs and lets you add custom spans and attributes.
+
+It then produces the exact env-var block for your case (with the Sematext-specific `X-API-TOKEN` header), suggests where to apply it in your project, and points you at the matching reference example you can use as a known-good baseline.
+
+## How to invoke it
+
+In [Claude Code](https://docs.claude.com/en/docs/claude-code), from your project directory:
+
+```text
+Use https://github.com/sematext/sematext-otel-onboarding/blob/main/skills/sematext-otel.md
+to instrument this codebase for Sematext.
+Region: US. App type: Tracing. Token: <your-tracing-app-token>.
+```
+
+(Swap region, App type, and token for your setup. You can paste it without those hints too — the skill will ask.)
+
+Other AI agents that can fetch a URL can load the same skill — it's plain markdown with no Claude-specific behavior.
+
+## What's actually in the skill
+
+The skill file is open source. You can read every line before letting an agent act on it. It contains:
+
+- The endpoint matrix for both regions (US/EU) and both protocols (HTTP/gRPC)
+- The full env-var block for the managed OTLP flow, including per-signal `X-API-TOKEN` headers
+- The env-var block and port table (4338 traces / 4318 metrics / 4328 logs) for the Sematext Agent flow
+- A pointer to the per-language reference example in the same repository, including build/run instructions
+- A troubleshooting table covering the common gotchas — region/token mismatch, the Bearer-vs-`X-API-TOKEN` header, auto-instrumentation not shipping logs, CORS for browser-side telemetry, port/protocol mismatches
+
+## What the skill is not
+
+- **Not a replacement for engineering judgment.** It writes the boilerplate that gets your service shipping telemetry. Custom span attributes, business metrics, custom log enrichment — those are still your call.
+- **Not magic.** The skill is plain markdown in a public repository. Nothing is hidden; you can audit it before running an agent against it.
+- **Not Sematext-specific software.** No vendor agent, no SDK fork, no proprietary tooling. Just documentation that happens to be structured for an AI to act on.
+
+## See also
+
+- [sematext-otel-onboarding repository](https://github.com/sematext/sematext-otel-onboarding) — reference examples for Node.js, Java, Python, .NET, and PHP, plus an end-to-end multi-service example for distributed tracing
+- [Creating a Tracing App](../tracing/create-tracing-app.md)
+- [OpenTelemetry SDKs](../tracing/sdks/index.md)
+- [Sematext Agent OpenTelemetry](../agents/sematext-agent/opentelemetry/index.md)

--- a/docs/tracing/create-tracing-app.md
+++ b/docs/tracing/create-tracing-app.md
@@ -3,6 +3,9 @@ description: Complete guide to creating and configuring a new Tracing App in Sem
 
 This guide walks you through the complete Tracing App creation process in Sematext Cloud, from initial setup through agent installation and application instrumentation.
 
+!!! tip "Using an AI coding agent?"
+    Load the [sematext-otel skill](/docs/guide/ai-powered-otel-onboarding/) into [Claude Code](https://docs.claude.com/en/docs/claude-code) (or any agent that can read a markdown URL) and it will walk you through the instrumentation conversationally — picking the right SDK, endpoint, protocol, and headers — and produce the exact env-var block ready to paste.
+
 **What is a Tracing App?** In Sematext, an [App](/docs/guide/app-guide/) is a container for your data. A Tracing App specifically collects and stores distributed traces from your applications, providing a dedicated space to analyze performance, errors, and dependencies. Each App is isolated and can have its own access controls, retention settings, and alert configurations.
 
 ## Prerequisites

--- a/docs/tracing/getting-started.md
+++ b/docs/tracing/getting-started.md
@@ -5,6 +5,9 @@ description: Learn how to set up distributed tracing with OpenTelemetry and Sema
 
 Sematext Tracing helps you monitor and troubleshoot distributed applications by tracking requests as they flow through your services. Built on OpenTelemetry, it provides visibility into performance bottlenecks, error propagation, and service dependencies.
 
+!!! tip "Using an AI coding agent?"
+    Load the [sematext-otel skill](/docs/guide/ai-powered-otel-onboarding/) into [Claude Code](https://docs.claude.com/en/docs/claude-code) (or any agent that can read a markdown URL) and it will walk you through OpenTelemetry instrumentation interactively, producing the env-var block and code changes for your stack.
+
 ## Prerequisites
 
 Before you begin, ensure you have:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
       - What is a Report?: guide/reports-guide.md
       - Features in This Screen Flyout: guide/features-in-this-screen.md
       - Integrations Guide: guide/integrations-guide.md
+      - AI-Powered OTel Onboarding: guide/ai-powered-otel-onboarding.md
       # - Logs Guide: guide/logs-guide.md
       # - Monitoring Guide: guide/monitoring-guide.md
       - Alerts Guide: guide/alerts-guide.md


### PR DESCRIPTION
## Summary

Documents the open-source [`sematext-otel` Agent Skill](https://github.com/sematext/sematext-otel-onboarding/blob/main/skills/sematext-otel.md) — an AI-readable markdown file that walks users through OpenTelemetry instrumentation for Sematext Cloud conversationally, then produces the exact env-var block and points at a runnable reference example. Adds a new standalone guide and three callout tips on the most relevant existing pages.

## What's in the PR

**New page**: `docs/guide/ai-powered-otel-onboarding.md` (under User Guide in the nav)

Covers:
- What the skill does (the six triage questions and what it produces)
- How to invoke it from Claude Code or any AI agent that can read a markdown URL
- What's inside the skill — endpoint matrix, env-var blocks for both flows, port table for the agent flow, troubleshooting table
- What the skill explicitly does *not* do (no custom span attributes, no magic, no vendor lock-in)

**Three callout tips** added to the most-trafficked OpenTelemetry pages, each ~3 lines, linking to the new guide:

- `docs/tracing/getting-started.md`
- `docs/tracing/create-tracing-app.md`
- `docs/agents/sematext-agent/opentelemetry/index.md`

**Nav**: new entry under "User Guide" between "Integrations Guide" and "Alerts Guide".

## Tone and framing

The page leans into honesty: the skill removes busywork, doesn't replace engineering judgment, is plain markdown anyone can audit. No "AI will solve everything" hype. The callouts are additive — they don't replace any existing instrumentation instructions, only point at the AI-driven alternative.

## Verified locally

Built and served with `mkdocs serve` from this branch. New page renders, all internal links resolve, callouts render as green "tip" admonitions on the three target pages, nav entry appears where intended.

## Skill source

https://github.com/sematext/sematext-otel-onboarding/blob/main/skills/sematext-otel.md

[SC-24946](https://sematext.atlassian.net/browse/SC-24946)


[SC-24946]: https://sematext.atlassian.net/browse/SC-24946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ