### PR TITLE
SC-24019 Add PHP SDK page and TypeScript mention to OpenTelemetry SDKs

### DIFF
--- a/docs/tracing/sdks/index.md
+++ b/docs/tracing/sdks/index.md
@@ -89,6 +89,7 @@ These languages have excellent auto-instrumentation support, making them ideal f
 ##### [Browser JavaScript](javascript-browser.md)
 - Auto-instrumentation: Automatic web instrumentation with `getWebAutoInstrumentations()`
 - Frameworks: React, Vue.js, Angular, vanilla JavaScript
+- TypeScript: First-class support — official `@types/*` packages and code samples in TypeScript throughout the guide
 - Features: User interaction tracking, API call tracing, fetch/XHR instrumentation
 - Deployment: Web server proxy, backend API proxy, development proxy
 
@@ -98,6 +99,12 @@ These languages have excellent auto-instrumentation support, making them ideal f
 - Features: Activity lifecycle tracking, network requests, user interactions
 - Platform: Android 5.0+ (API level 21+)
 - Requires backend proxy for trace export
+
+##### [PHP](php.md)
+- Auto-instrumentation: Requires the OpenTelemetry PHP extension (`ext-opentelemetry`) plus framework packages
+- Frameworks: Laravel, Symfony, Slim, vanilla PHP
+- Libraries: PDO, Guzzle HTTP, MySQL, Redis (via per-package instrumentations)
+- Platform: PHP 8.2+
 
 ### Manual Instrumentation Focused
 
@@ -125,7 +132,6 @@ These languages typically require manual instrumentation, though some limited au
 
 Don't see your language? OpenTelemetry supports many more languages:
 
-- PHP: OpenTelemetry PHP with framework support
 - Rust: Growing ecosystem with basic instrumentation
 - C++: Core OpenTelemetry C++ SDK
 - Erlang/Elixir: Community-driven instrumentations
@@ -245,6 +251,7 @@ export OTEL_TRACES_SAMPLER_ARG=0.1
 | Python   | ✅ Excellent        | ✅ Full      | ✅ Yes        | ✅ Comprehensive  | ⚡ Good     |
 | Node.js  | ✅ Excellent        | ✅ Full      | ✅ Native     | ✅ Comprehensive  | ⚡ Excellent |
 | .NET     | ✅ Good             | ✅ Full      | ✅ Yes        | ✅ Good           | ⚡ Excellent |
+| PHP      | ✅ Good             | ✅ Full      | ✅ Partial    | ⚡ Good           | ⚡ Good     |
 | Go       | ⚠️ Manual          | ✅ Full      | ✅ Yes        | ⚡ Growing       | ⚡ Excellent |
 | Ruby     | ⚠️ Limited         | ✅ Full      | ✅ Partial    | ⚡ Good          | ⚡ Good     |
 

--- a/docs/tracing/sdks/php.md
+++ b/docs/tracing/sdks/php.md
@@ -1,0 +1,171 @@
+title: PHP OpenTelemetry SDK for Sematext Tracing
+description: Complete guide to instrumenting PHP applications (Laravel, Symfony, vanilla PHP) with OpenTelemetry for Sematext Tracing
+
+## PHP OpenTelemetry SDK
+
+This guide covers how to instrument PHP applications with OpenTelemetry to send traces (and optionally metrics and logs) to Sematext. Both auto-instrumentation (via the OpenTelemetry PHP extension) and manual instrumentation are supported.
+
+## Prerequisites
+
+- PHP 8.2 or newer
+- [Composer](https://getcomposer.org/) for dependency management
+- The OpenTelemetry PHP extension (`ext-opentelemetry`) for auto-instrumentation
+- A Sematext App ([create one](/docs/tracing/create-tracing-app/)) and your token
+- One of:
+    - The [Sematext Agent](/docs/agents/sematext-agent/opentelemetry/) running locally (agent flow), or
+    - Direct connectivity to the [managed OTLP endpoint](/docs/guide/managed-otlp-endpoint/) (managed flow)
+
+## Install the OpenTelemetry PHP extension
+
+Auto-instrumentation requires a PHP extension that hooks into the runtime. Install it with PECL:
+
+```bash
+pecl install opentelemetry
+```
+
+Enable it in `php.ini`:
+
+```ini
+extension=opentelemetry.so
+```
+
+Verify:
+
+```bash
+php -m | grep opentelemetry
+```
+
+You can skip this extension if you only plan to use manual instrumentation — but auto-instrumentation is much faster to get started with.
+
+## Install OpenTelemetry packages
+
+In your project root:
+
+```bash
+composer require \
+  open-telemetry/sdk \
+  open-telemetry/exporter-otlp \
+  open-telemetry/opentelemetry-auto-laravel
+```
+
+Swap `opentelemetry-auto-laravel` for the appropriate auto-instrumentation package for your framework (Symfony, Slim, etc.) — see the [OpenTelemetry PHP registry](https://opentelemetry.io/ecosystem/registry/?language=php) for the full list.
+
+## Configure environment variables
+
+The OpenTelemetry PHP SDK reads its configuration from environment variables. Pick the flow that matches your setup.
+
+### Flow A — Sematext Agent (default in the per-language examples)
+
+```bash
+export OTEL_PHP_AUTOLOAD_ENABLED=true
+export OTEL_SERVICE_NAME=your-service-name
+export OTEL_SERVICE_VERSION=1.0.0
+
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=none   # auto-instrumentation doesn't ship logs
+
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4338
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+`OTEL_PHP_AUTOLOAD_ENABLED=true` is required for the PHP SDK to bootstrap automatically when the extension is loaded.
+
+### Flow B — Managed OTLP endpoint (no agent)
+
+```bash
+export OTEL_PHP_AUTOLOAD_ENABLED=true
+export OTEL_SERVICE_NAME=your-service-name
+export OTEL_SERVICE_VERSION=1.0.0
+
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=none
+
+# Pick US or EU based on your account region
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-receiver.eu.sematext.com
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+# Per-signal tokens — only set the ones for Apps you've actually created
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS=X-API-TOKEN=<tracing-app-token>
+export OTEL_EXPORTER_OTLP_METRICS_HEADERS=X-API-TOKEN=<monitoring-app-token>
+```
+
+See [Managed OTLP Endpoint](/docs/guide/managed-otlp-endpoint/) for the full endpoint matrix (US/EU × HTTP/gRPC), compression options, and troubleshooting.
+
+## Auto vs manual instrumentation
+
+| Style | Traces | Metrics | Logs | Code changes |
+|---|---|---|---|---|
+| **Auto-instrumentation** | ✅ | ✅ | ❌ | None — just env vars + the extension |
+| **Manual instrumentation** | ✅ | ✅ | ✅ | Explicit SDK init + span creation |
+
+Auto-instrumentation is the recommended starting point for Laravel, Symfony, and other supported frameworks. Switch to (or add) manual instrumentation when you need:
+
+- Custom spans around your own business logic
+- Custom span attributes (user tier, feature flag, etc.)
+- Log shipping (auto doesn't cover OTel logs in PHP today)
+
+The two styles compose: you can add manual spans on top of auto-instrumentation in the same application.
+
+## Manual instrumentation example
+
+Bootstrap the SDK and create a custom span:
+
+```php
+<?php
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Trace\StatusCode;
+
+require __DIR__ . '/vendor/autoload.php';
+
+$tracer = Globals::tracerProvider()->getTracer('my-service');
+
+$span = $tracer->spanBuilder('checkout')->startSpan();
+$scope = $span->activate();
+try {
+    $span->setAttribute('user.tier', $userTier);
+    // ... your code ...
+    $span->setStatus(StatusCode::STATUS_OK);
+} catch (\Throwable $e) {
+    $span->recordException($e);
+    $span->setStatus(StatusCode::STATUS_ERROR, $e->getMessage());
+    throw $e;
+} finally {
+    $scope->detach();
+    $span->end();
+}
+```
+
+The SDK reads its exporter config from the same `OTEL_EXPORTER_OTLP_*` env vars as auto-instrumentation, so the same Flow A / Flow B blocks above apply.
+
+## Running a worked example
+
+The [`sematext-otel-onboarding`](https://github.com/sematext/sematext-otel-onboarding) repository has a complete Laravel example with both auto and manual instrumentation, for baremetal / Docker / Kubernetes:
+
+- [`php/baremetal/auto-instrumentation/laravel/`](https://github.com/sematext/sematext-otel-onboarding/tree/main/php/baremetal/auto-instrumentation/laravel)
+- [`php/baremetal/manual-instrumentation/laravel/`](https://github.com/sematext/sematext-otel-onboarding/tree/main/php/baremetal/manual-instrumentation/laravel)
+- [`php/docker/`](https://github.com/sematext/sematext-otel-onboarding/tree/main/php/docker) — Docker variants
+- [`php/kubernetes/`](https://github.com/sematext/sematext-otel-onboarding/tree/main/php/kubernetes) — Kubernetes variants
+
+Clone the repo and follow the per-example README — they're self-contained, ready to run against a Sematext account, and a good baseline if your project gets stuck.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `php -m | grep opentelemetry` returns nothing | Extension installed but not enabled in `php.ini` — confirm with `php --ini` to see which file is loaded |
+| Auto-instrumentation isn't producing any spans | `OTEL_PHP_AUTOLOAD_ENABLED=true` is missing, or the framework-specific package (`opentelemetry-auto-laravel`, etc.) isn't installed |
+| Traces ship but metrics don't | `OTEL_METRICS_EXPORTER=otlp` not set, or the metrics endpoint isn't reachable |
+| Logs don't ship even with manual instrumentation | OTel logs in PHP are newer — confirm your `open-telemetry/sdk` version and logger configuration |
+| 401 / 403 from the managed endpoint | Token in `OTEL_EXPORTER_OTLP_*_HEADERS` is for the wrong region, or sent as `Authorization: Bearer` instead of `X-API-TOKEN` |
+
+## See also
+
+- [OpenTelemetry PHP documentation](https://opentelemetry.io/docs/languages/php/)
+- [OpenTelemetry PHP auto-instrumentation](https://opentelemetry.io/docs/zero-code/php/)
+- [Managed OTLP Endpoint](/docs/guide/managed-otlp-endpoint/) — direct-to-Sematext flow
+- [Sematext Agent OpenTelemetry](/docs/agents/sematext-agent/opentelemetry/) — local-agent flow
+- [AI-Powered OTel Onboarding](/docs/guide/ai-powered-otel-onboarding/) — interactive setup
+- [sematext-otel-onboarding repository](https://github.com/sematext/sematext-otel-onboarding) — runnable PHP examples

--- a/docs/tracing/sdks/php.md
+++ b/docs/tracing/sdks/php.md
@@ -140,7 +140,7 @@ try {
 
 The SDK reads its exporter config from the same `OTEL_EXPORTER_OTLP_*` env vars as auto-instrumentation, so the same Flow A / Flow B blocks above apply.
 
-## Running a worked example
+## Running a working example
 
 The [`sematext-otel-onboarding`](https://github.com/sematext/sematext-otel-onboarding) repository has a complete Laravel example with both auto and manual instrumentation, for baremetal / Docker / Kubernetes:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
         - Node.js: tracing/sdks/nodejs.md
         - Go: tracing/sdks/go.md
         - .NET: tracing/sdks/dotnet.md
+        - PHP: tracing/sdks/php.md
         - Ruby: tracing/sdks/ruby.md
         - Browser JavaScript: tracing/sdks/javascript-browser.md
         - Android: tracing/sdks/android.md


### PR DESCRIPTION
## Summary

Adds PHP as a first-class entry in the OpenTelemetry SDKs section and makes TypeScript support explicit in the Browser JavaScript entry.

## Changes

### New page: `docs/tracing/sdks/php.md`

Mirrors the structure of the existing per-language SDK pages (Java, Python, Node.js, Ruby). Covers:

- PHP 8.2+ + Composer prerequisites
- Installing the `ext-opentelemetry` PHP extension via PECL
- Composer install for the OTel SDK + OTLP exporter + framework auto-instrumentation
- Two env-var blocks, side by side:
    - **Flow A — Sematext Agent** (matches the per-language example READMEs in `sematext-otel-onboarding`)
    - **Flow B — managed OTLP endpoint** (per-signal `X-API-TOKEN` headers, US/EU)
- Auto vs manual instrumentation table — what each gives you, when to pick each
- Manual instrumentation code example (custom span + status codes + exception recording)
- Cross-links to the runnable Laravel examples in `sematext-otel-onboarding`
- Troubleshooting table for the common PHP-specific gotchas (extension not enabled, missing `OTEL_PHP_AUTOLOAD_ENABLED`, etc.)

### `docs/tracing/sdks/index.md` updates

- **PHP elevated** from the "Other Languages" footnote bullet to a first-class entry under *Auto-Instrumentation Recommended*, between Android and the manual-focused section. Modern PHP auto-instrumentation via `ext-opentelemetry` is mature enough to belong here.
- **PHP row added** to the Feature Comparison table at the bottom of the page.
- **TypeScript called out** explicitly in the Browser JavaScript entry — official `@types/*` packages, TypeScript code samples throughout the existing browser SDK guide. Previously implicit (the guide has TypeScript snippets but the SDK index didn't mention TypeScript support).

### `mkdocs.yml`

- PHP nav entry under *OpenTelemetry SDKs*, alphabetically between .NET and Ruby.

## Verified locally

Built with `mkdocs serve`, confirmed:
- New PHP page renders, all internal and external links resolve
- SDK index shows PHP in the right section + the comparison table
- TypeScript bullet appears in the Browser JavaScript entry
- Left nav shows the PHP entry between .NET and Ruby
- No broken-link warnings from mkdocs

[SC-24019](https://sematext.atlassian.net/browse/SC-24019)


[SC-24019]: https://sematext.atlassian.net/browse/SC-24019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ