### PR TITLE
[SC-25208] docs: document AIMONITORING_RECEIVER_URL container env var

### DIFF
--- a/docs/agents/sematext-agent/containers/configuration.md
+++ b/docs/agents/sematext-agent/containers/configuration.md
@@ -78,6 +78,7 @@ docker run -d --restart always --privileged -P --name st-agent --memory 512MB \
 -e SERVER_BASE_URL=https://spm-receiver.sematext.com \
 -e LOGS_RECEIVER_URL=https://logsene-receiver.sematext.com \
 -e EVENTS_RECEIVER_URL=https://event-receiver.sematext.com \
+-e AIMONITORING_RECEIVER_URL=https://aimonitoring-receiver.sematext.com \
 -e COMMAND_SERVER_URL=https://command.sematext.com \
 sematext/agent:latest-4
 ```
@@ -98,6 +99,7 @@ docker run -d --restart always --privileged -P --name st-agent --memory 512MB \
 -e SERVER_BASE_URL=https://spm-receiver.sematext.com \
 -e LOGS_RECEIVER_URL=https://logsene-receiver.sematext.com \
 -e EVENTS_RECEIVER_URL=https://event-receiver.sematext.com \
+-e AIMONITORING_RECEIVER_URL=https://aimonitoring-receiver.sematext.com \
 -e COMMAND_SERVER_URL=https://command.sematext.com \
 -e CONTAINER_SKIP_BY_IMAGE=nginx \
 sematext/agent:latest-4
@@ -130,6 +132,7 @@ services:
       - SERVER_BASE_URL=https://spm-receiver.sematext.com
       - LOGS_RECEIVER_URL=https://logsene-receiver.sematext.com
       - EVENTS_RECEIVER_URL=https://event-receiver.sematext.com
+      - AIMONITORING_RECEIVER_URL=https://aimonitoring-receiver.sematext.com
       - COMMAND_SERVER_URL=https://command.sematext.com
       - CONTAINER_SKIP_BY_IMAGE=nginx
     cap_add:

--- a/docs/agents/sematext-agent/containers/installation.md
+++ b/docs/agents/sematext-agent/containers/installation.md
@@ -24,7 +24,7 @@ _[Read more](/docs/agents/sematext-agent/permission-requirements/#bind-mounts) a
 
 Besides providing several bind mounts for Docker socket, _procfs_ and journal directory, App tokens are required to ship data to the appropriate Monitoring Apps. Sematext Agent will gather data about running processes on the system, basic operating system metrics, machine/instance-related information, and ship it to the Infra App token. It will also detect active containers and start collecting different container metrics such as memory usage, network I/O statistics, disk throughput, etc.
 
-By default, the US region receiver endpoints are used to ship data to Sematext Cloud. You can override receiver addresses by either passing `SERVER_BASE_URL` for metrics receivers, `LOGS_RECEIVER_URL` and `EVENTS_RECEIVER_URL` for log and event receivers respectively, or specify an alternative (`EU`) region via the `REGION` environment variable.
+By default, the US region receiver endpoints are used to ship data to Sematext Cloud. You can override receiver addresses by either passing `SERVER_BASE_URL` for metrics receivers, `LOGS_RECEIVER_URL`, `EVENTS_RECEIVER_URL`, and `AIMONITORING_RECEIVER_URL` for log, event, and AI agent monitoring receivers respectively, or specify an alternative (`EU`) region via the `REGION` environment variable.
 
 **Note that if any of the** `*_URL` **environment variables are set, region-specific receiver endpoints are ignored.**
 


### PR DESCRIPTION
## What

Documents the `AIMONITORING_RECEIVER_URL` container env var for the AI-agent monitoring receiver.

## Changes

- `agents/sematext-agent/containers/configuration.md` — env var in the docker run + compose examples.
- `agents/sematext-agent/containers/installation.md` — receiver override list.