### PR TITLE
[SC-25388] docs(logs): rewrite Script Field Processor page for CEL

### DIFF
--- a/docs/logs/script-field-processor.md
+++ b/docs/logs/script-field-processor.md
@@ -1,38 +1,39 @@
 title: Script Field Processor
 description: Logs Pipeline Processors
 
-Scripting is supported using the Script processor. It uses [painless](https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-guide.html), a simple scripting language similar to Java. 
-You can access fields using the `doc` method. Since the field value can be of any type, before using it you must cast the value to a specific type like: String, Integer, Double, etc.
+Scripting is supported using the Script Field processor. Scripts are written in [CEL — Common Expression Language](https://cel.dev/), a simple and safe expression language. A script is a single CEL expression that is evaluated for each log event, and its result is stored in the configured target field.
+
+You can access fields using the `doc` variable, e.g. `doc['severity']` or `doc.severity`. Use the bracket form for field names containing dots, e.g. `doc['os.host']`. String fields can be used directly. Numeric fields must be converted explicitly before arithmetic or comparison, using `int()` for whole numbers or `double()` for decimals, e.g. `int(doc['size'])`. Accessing a missing field returns `null`.
 
 The following is supported:
 
-- Math operators: +, -, /, *, %, ^, e.g. `((Integer)doc['size.kb']).intValue()*2`
-- Relational operators: ==, !=, <, <=, >, >=, e.g. `((Integer)doc['size']).intValue() > 10`
-- Logical operators: &&, ||, !, e.g. `((Integer)doc['size']).intValue() > -1 && ((Integer)doc['size']).intValue() < 10`
-- Ternary operator, e.g. `((Integer)doc['speed']).intValue() < 1000 ? "OK" : "SLOW"`
-- String functions, e.g. `((String)doc['severity']).toUpperCase()` or `((String)doc['message']).splitOnToken('-')[3]`
+- Math operators: +, -, /, *, %, e.g. `int(doc['size.kb']) * 2`
+- Relational operators: ==, !=, <, <=, >, >=, e.g. `int(doc['size']) > 10`
+- Logical operators: &&, ||, !, e.g. `int(doc['size']) > -1 && int(doc['size']) < 10`
+- Ternary operator, e.g. `int(doc['speed']) < 1000 ? "OK" : "SLOW"`
+- String functions such as `split`, `replace`, `substring`, `indexOf`, `trim`, `lowerAscii`, `upperAscii`, `startsWith`, `endsWith`, `contains`, `matches`, e.g. `doc['severity'].upperAscii()` or `doc['message'].split('-')[3]`
+- Field presence test with `has()`, e.g. `has(doc.severity)`. For field names containing dots, use `doc['os.host'] != null` instead
+- Naming a sub-expression with `cel.bind()` so it is computed once and reused
+- Returning a map, which sets several fields at once — the target field is then ignored
 
-Conditional block and loops are supported. The last line should result in a value that will then be stored as a field.  Here is a made up example:
-
-```java
-String[] tokens = ((String)doc['message']).splitOnToken(' '); 
-if(tokens.length % 2 != 0){
-  String result = "Iterator ";
-  for(int i = 0; i < tokens.length; i++){
-      result += i;
-  }
-  result;
-}
-else {
-  tokens.length * 10;
-}
-```
+Loops and comprehensions (`map`, `filter`, `all`, `exists`) are not supported — a script is always a single expression, and scripts using them are rejected when the pipeline is saved. If a script fails at runtime for a log event — for example, a string function is called on a missing field — the event continues through the pipeline unchanged; a script never drops an event.
 
 Imagine we have a message field:
 `Got document of 142 kb from 255.35.244.0`
-and that we want to extract the number of kilobytes. The script might look something like:
+and that we want to extract the number of kilobytes. Since the fields are space-separated, the simplest script is:
 
-```java
-int kbIdx = ((String)doc['message']).indexOf(' kb');
-((String)doc['message']).substring(17, kbIdx)
+```javascript
+doc['message'].split(' ')[3]
+```
+
+The same value can be extracted by position, using `cel.bind()` to avoid repeating the field access:
+
+```javascript
+cel.bind(msg, doc['message'], msg.substring(16, msg.indexOf(' kb')))
+```
+
+To set several fields from one script, return a map. For example, with a `raw` field containing `ERROR|10.1.1.0`, the following stores `ERROR` in the `status` field and `10.1.1.0` in the `ip` field:
+
+```javascript
+cel.bind(p, doc['raw'].split('|'), {'status': p[0], 'ip': p[1]})
 ```


### PR DESCRIPTION
## Goal

The SCRIPT_FIELD pipeline processor engine moved from Painless to CEL — Common Expression Language ([SC-25285](https://sematext.atlassian.net/browse/SC-25285), sematext-cloud PR #8149). This rewrites https://sematext.com/docs/logs/script-field-processor/ to match the deployed engine, alongside the editor update in sematext-cloud PR [#8210](https://github.com/sematext/sematext-cloud/pull/8210) ([SC-25388](https://sematext.atlassian.net/browse/SC-25388)).

## Changes

- Language is CEL (linked to https://cel.dev/), a single expression per script.
- `doc['field']` / `doc.field` access; bracket form for dotted names; missing fields read as `null`.
- **Numeric fields need explicit `int()` / `double()` conversion** — log bodies are decoded with `UseNumber`, so numbers reach CEL string-backed; bare `doc['size'] * 2` fails at runtime. All numeric examples show the conversion.
- `has()` presence test, with `doc['os.host'] != null` for dotted names (`has()` can't take bracket syntax).
- String helpers, `cel.bind()`, and map results setting several fields at once (target then ignored).
- No loops/comprehensions (rejected at save); runtime script failure leaves the event unchanged, never drops it.
- Replaced the Painless loop example (inexpressible in CEL) with verified CEL examples — every example on the page was executed against the actual engine environment, including the old page's kb-extraction example, whose `substring(17, …)` was off by one (produced "42", not "142").

## Verification

All claims and examples were validated by running them against the real `scriptEnv` from `go/consumer/cmd/logs/pipelines/proc/script.go` (cel-go v0.20.1) with production-shaped (`UseNumber`-decoded) records.

[SC-25285]: https://sematext.atlassian.net/browse/SC-25285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SC-25388]: https://sematext.atlassian.net/browse/SC-25388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ