### PR TITLE
[SC-23335] docs(network-map): set minimum Sematext Agent version

### DIFF
--- a/docs/network-map/getting-started.md
+++ b/docs/network-map/getting-started.md
@@ -9,7 +9,7 @@ Network Map requires two things:
 
 **An [Infra App](/docs/monitoring/infrastructure/)** to collect and store your infrastructure data. If you're already using Sematext for infrastructure monitoring, you have this. If not, you'll create one as part of the setup process.
 
-**[Sematext Agent](/docs/agents/sematext-agent/installation/)** installed on the hosts you want to monitor. The agent collects eBPF-based network connection data that powers Network Map's topology visualization. You need **version 4.4.0 or later** on Kubernetes/Docker, or the **`sematext-agent` 4.11.15 or later** package on bare-metal Linux hosts.
+**[Sematext Agent](/docs/agents/sematext-agent/installation/)** installed on the hosts you want to monitor. The agent collects eBPF-based network connection data that powers Network Map's topology visualization. You need **version 4.4.0 or later**.
 
 For best results, your hosts should be running **Linux kernel 5.8 or later**. Older kernels (4.15+) work but with some limitations. Check your kernel version with `uname -r`.
 

--- a/docs/network-map/getting-started.md
+++ b/docs/network-map/getting-started.md
@@ -9,7 +9,7 @@ Network Map requires two things:
 
 **An [Infra App](/docs/monitoring/infrastructure/)** to collect and store your infrastructure data. If you're already using Sematext for infrastructure monitoring, you have this. If not, you'll create one as part of the setup process.
 
-**[Sematext Agent](/docs/agents/sematext-agent/installation/)** installed on the hosts you want to monitor. The agent collects eBPF-based network connection data that powers Network Map's topology visualization. You need version 4.1.x or later.
+**[Sematext Agent](/docs/agents/sematext-agent/installation/)** installed on the hosts you want to monitor. The agent collects eBPF-based network connection data that powers Network Map's topology visualization. You need **version 4.4.0 or later** on Kubernetes/Docker, or the **`sematext-agent` 4.11.15 or later** package on bare-metal Linux hosts.
 
 For best results, your hosts should be running **Linux kernel 5.8 or later**. Older kernels (4.15+) work but with some limitations. Check your kernel version with `uname -r`.
 

--- a/docs/network-map/index.md
+++ b/docs/network-map/index.md
@@ -54,7 +54,7 @@ Beyond day-to-day monitoring, Network Map helps with scenarios that are hard to 
 To use Network Map, you need:
 
 1. At least one [Infra App](/docs/monitoring/infrastructure/) created in Sematext Cloud
-2. [Sematext Agent](/docs/agents/sematext-agent/) installed on your hosts (version 4.1.x or later)
+2. [Sematext Agent](/docs/agents/sematext-agent/) installed on your hosts — **4.4.0 or later** on Kubernetes/Docker, or the **`sematext-agent` 4.11.15 or later** package on bare metal
 
 Once enabled, Network Map starts collecting data immediately. Within a few minutes, you'll see your first topology visualization.
 

--- a/docs/network-map/index.md
+++ b/docs/network-map/index.md
@@ -54,7 +54,7 @@ Beyond day-to-day monitoring, Network Map helps with scenarios that are hard to 
 To use Network Map, you need:
 
 1. At least one [Infra App](/docs/monitoring/infrastructure/) created in Sematext Cloud
-2. [Sematext Agent](/docs/agents/sematext-agent/) installed on your hosts — **4.4.0 or later** on Kubernetes/Docker, or the **`sematext-agent` 4.11.15 or later** package on bare metal
+2. [Sematext Agent](/docs/agents/sematext-agent/) installed on your hosts (**version 4.4.0 or later**)
 
 Once enabled, Network Map starts collecting data immediately. Within a few minutes, you'll see your first topology visualization.
 

--- a/docs/network-map/troubleshooting.md
+++ b/docs/network-map/troubleshooting.md
@@ -9,7 +9,7 @@ Network Map requires:
 
 **An Infra App** in your Sematext Cloud account. The Infra App collects infrastructure metrics and provides the foundation for Network Map's topology visualization. If you don't have one, create one at [Sematext Cloud US](https://apps.sematext.com/ui/infrastructure/create) or [Sematext Cloud EU](https://apps.eu.sematext.com/ui/infrastructure/create).
 
-**[Sematext Agent](/docs/agents/sematext-agent/installation/) version 4.1.x or later** installed on your hosts. The agent collects the eBPF-based network connection data that powers Network Map. Check your agent version with `sematext-agent --version`.
+**[Sematext Agent](/docs/agents/sematext-agent/installation/)** installed on your hosts — **version 4.4.0 or later** on Kubernetes/Docker, or the **`sematext-agent` 4.11.15 or later** package on bare-metal Linux hosts. The agent collects the eBPF-based network connection data that powers Network Map. Check each host's agent version in [Fleet](/docs/fleet/).
 
 **Linux kernel 5.8 or later** for optimal performance. Network Map uses eBPF with ring buffers, which requires kernel 5.8+. Older kernels (4.15+) work but with reduced performance and some limitations. Check your kernel version with `uname -r`.
 
@@ -24,7 +24,7 @@ This typically happens when you've added Network Map to an environment where age
 To resolve this:
 
 1. Click the warning banner to see which hosts have outdated agents, or use [Fleet](/docs/fleet/) to view all your agents and their versions
-2. Update those agents to version 4.1.x or later
+2. Update those agents — to **4.4.0 or later** on Kubernetes/Docker, or the **`sematext-agent` 4.11.15 or later** package on bare metal
 3. The warning disappears once all agents are current
 
 Follow the [Sematext Agent update instructions](/docs/agents/sematext-agent/installation/) to upgrade your agents to the latest version.

--- a/docs/network-map/troubleshooting.md
+++ b/docs/network-map/troubleshooting.md
@@ -9,7 +9,7 @@ Network Map requires:
 
 **An Infra App** in your Sematext Cloud account. The Infra App collects infrastructure metrics and provides the foundation for Network Map's topology visualization. If you don't have one, create one at [Sematext Cloud US](https://apps.sematext.com/ui/infrastructure/create) or [Sematext Cloud EU](https://apps.eu.sematext.com/ui/infrastructure/create).
 
-**[Sematext Agent](/docs/agents/sematext-agent/installation/)** installed on your hosts — **version 4.4.0 or later** on Kubernetes/Docker, or the **`sematext-agent` 4.11.15 or later** package on bare-metal Linux hosts. The agent collects the eBPF-based network connection data that powers Network Map. Check each host's agent version in [Fleet](/docs/fleet/).
+**[Sematext Agent](/docs/agents/sematext-agent/installation/)** installed on your hosts — **version 4.4.0 or later**. The agent collects the eBPF-based network connection data that powers Network Map. Check each host's agent version in [Fleet](/docs/fleet/).
 
 **Linux kernel 5.8 or later** for optimal performance. Network Map uses eBPF with ring buffers, which requires kernel 5.8+. Older kernels (4.15+) work but with reduced performance and some limitations. Check your kernel version with `uname -r`.
 
@@ -24,7 +24,7 @@ This typically happens when you've added Network Map to an environment where age
 To resolve this:
 
 1. Click the warning banner to see which hosts have outdated agents, or use [Fleet](/docs/fleet/) to view all your agents and their versions
-2. Update those agents — to **4.4.0 or later** on Kubernetes/Docker, or the **`sematext-agent` 4.11.15 or later** package on bare metal
+2. Update those agents to **version 4.4.0 or later**
 3. The warning disappears once all agents are current
 
 Follow the [Sematext Agent update instructions](/docs/agents/sematext-agent/installation/) to upgrade your agents to the latest version.


### PR DESCRIPTION
Set a single minimum agent version — **4.4.0 or later** — on the three Network Map pages (getting-started, index, troubleshooting), and point "check your agent version" at Fleet.
