### PR TITLE
SC-24603 Initial docs for the Sematext Cloud MCP Server

### DIFF
--- a/docs/mcp/getting-started.md
+++ b/docs/mcp/getting-started.md
@@ -1,0 +1,54 @@
+title: Getting Started
+description: Installation instructions for the Sematext Cloud MCP Server
+
+Installing the Sematext Cloud MCP Server is fairly simple, with the setup varying based on which AI agent provider you use. This page contains guides on how to install it with various providers.
+
+
+
+## Getting your API Key
+
+While the setup may vary based on which AI agent provider you're using, all of them will require your Sematext Cloud API Key in order to authenticate.
+
+Your account's API Key can be found on the **Settings → API** page:
+
+- [here](https://apps.sematext.com/ui/account/api), if your account is registered in the US region, or
+- [here](https://apps.eu.sematext.com/ui/account/api), for the EU region
+
+
+
+## Setup guides
+
+This section contains the setup guides for different agent providers.
+
+
+### Claude Code
+
+Installing the Sematext Cloud MCP Server for Claude Code is super simple - it can be done with a single command! Just make sure to replace the `apiKey` here with your real API Key.
+
+If your account is on the US region, run this command:
+
+```bash
+claude mcp add --transport http --scope user sematext-cloud https://mcp.sematext.com/mcp --header "Authorization: apiKey xxxx-xx-xx-xxxx"
+```
+
+If you're on EU, run this command instead:
+
+```bash
+claude mcp add --transport http --scope user sematext-cloud https://mcp.eu.sematext.com/mcp --header "Authorization: apiKey xxxx-xx-xx-xxxx"
+```
+
+
+#### Verifying the installation
+
+Once you have installed the MCP Server, you can verify that it works with the following command:
+```bash
+claude mcp list
+```
+
+The output should be this:
+```
+sematext-cloud: https://mcp.sematext.com/mcp (HTTP) - ✔ Connected
+```
+
+If you see any errors, please check that you have provided the correct API key.
+

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -1,0 +1,76 @@
+title: Sematext Cloud MCP Server
+description: An overview of the Sematext Cloud MCP Server and its functionality, as well as examples of how it helps you troubleshoot issues
+
+Sematext Cloud offers many observability solutions, letting you store and analyze your Logs, monitor your Infrastructure, or check which Events happened. While these can be viewed and manually correlated within the UI, you can now also let your AI agent of choice query Sematext Cloud for your data and correlate it.
+
+
+
+## About the MCP Server
+
+The [Model Context Protocol](https://modelcontextprotocol.io/) (abbreviated as MCP) is an open standard that lets AI agents such as Claude or ChatGPT connect to external data sources - in this case Sematext Cloud. The Sematext Cloud MCP Server is thus the bridge between your AI agent and your observability data. Instead of copy-pasting logs into a chat or clicking through dashboards yourself, you describe the problem and the agent fetches the relevant logs, metrics, traces, and alerts - and correlates them for you.
+
+The MCP Server has read-only access to your data. Your AI agent can query your logs, metrics, and traces, but it can't modify alert rules, Apps, or anything else in your account, making it safe to use with your preferred AI agent.
+
+
+### How it works
+
+1. You ask your AI agent a question, like *"Why did our error rate spike at 14:00?"*
+2. The agent picks the right tools for the job - it might search your logs, query your metrics, or check which alerts fired.
+3. The agent queries Sematext Cloud on your behalf, using your API Key, and combines the results into an answer.
+
+
+
+## Features
+
+Currently, the MCP Server gives your AI agents access to the following features:
+
+- Checking your Sematext Cloud Apps to see what's available and which Apps are shipping data
+- Searching for logs in your [Logs Apps](../logs/index.md) and providing context for them
+- Fetching an overview of how the hosts and containers making up your [Infrastructure](../monitoring/infrastructure.md) are doing
+- Querying metrics from your various [Monitoring Apps](../monitoring/index.md) to preemptively detect issues or troubleshoot live ones
+- Viewing the [Alerts](../alerts/index.md) you have configured and which ones fired, letting you quickly correlate between different App types
+- Browsing your Traces - both the general overview and the individual Traces - to check exactly which services cause errors and under which conditions
+
+
+### Usage examples
+
+Since the tools which provide these features come with detailed descriptions for the AI agents, you can easily get information about the services you're monitoring by asking questions such as:
+
+- *Hey, we're seeing a spike in errors across our infrastructure. Can you check our logs from the last 24 hours and tell me what's going on? I need to know what kinds of errors we're dealing with, how many there are, and which hosts are affected.*
+- *Users are complaining about slow load times. Can you check the traces for any slow requests?*
+- *I found a slow trace in our tracing app. Can you find the slowest trace from the last hour and then show me the full span breakdown? I want to see where the time is being spent.*
+- *I'm seeing some error traces in our services. Can you find the recent error traces and then check the logs around the same timeframe to see if there are related error messages?*
+- *How's our infrastructure looking? Any hosts having issues?*
+- *Can you check the health of our web servers? The hostnames start with "web-".*
+- *What's the peak memory each of our hosts hit over the past week? I'm sizing instances for next quarter.*
+- *I want to understand our alert health. Which of our alert rules have actually fired recently? Are there rules that are configured but never trigger (maybe the thresholds are too loose)? And are there rules firing constantly that we've become numb to?*
+- *I think someone disabled some alerts for maintenance last week and forgot to turn them back on. Can you check if we have any disabled alert rules? Especially the high-priority ones, those should never stay off.*
+- *We deployed at 14:00 UTC today. Is the error rate worse since then compared to the hour before the deploy?*
+
+
+
+### Tools
+
+This is a brief overview of what the specific tools that the MCP Server provides do.
+
+| Tool | What it does |
+|------|-------------|
+| `list_apps` | Lists all Apps in your account |
+| `query_logs` | Searches a Logs App for a specific message within the provided interval |
+| `get_log_context` | Fetches logs surrounding a specific log entry to get more context |
+| `list_metrics` | Discovers available metric names in an App |
+| `list_dimensions` | Discovers tag names and values for filtering and grouping |
+| `query_metrics` | Queries metrics as a timeseries or summary |
+| `list_alert_rules` | Lists configured alert rule definitions |
+| `list_alert_events` | Lists fired alert incidents |
+| `list_events` | Lists deployment, infrastructure, and custom events |
+| `get_infra_overview` | Snapshot of host and container health |
+| `query_traces` | Searches traces by service, duration, status, and attributes |
+| `get_trace` | Full span tree for a single trace |
+| `get_traces_overview` | Tracing health snapshot with error rate and latency percentiles |
+
+
+
+## Setting up the MCP Server
+
+Setting up the MCP Server with your preferred AI agent can be done in under 5 minutes. Depending on which AI provider you use, the setup varies slightly, and you can check out the exact install instructions [here](/docs/mcp/getting-started).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -508,6 +508,9 @@ nav:
         - FAQ: logagent/faq.md
       - Mobile App SDKs: agents/mobile.md
       - Browser SDK: agents/browser.md
+    - MCP:
+      - Overview: mcp/index.md
+      - Getting Started: mcp/getting-started.md
     - API: api/index.md
     - FAQ: faq.md
 


### PR DESCRIPTION
This PR adds the initial docs for the Sematext Cloud MCP Server. I purposefully wanted to keep this short and sweet compared to our internal docs to not scare people away with a wall of text, and I believe the current form contains all the important information that a user could need. Sadly not a whole lot to screenshot so it'll be text-only, unless we want to create some graphics on how this works.

The `Tools` section of the overview feels a bit overkill, but it's at the bottom of the page so it shouldn't matter much. If you agree on it being unnecessary then we can get rid of it.

We'll also need to add the specific setup guides for the various AI agent providers later on down the line. I'll mention this during the demos and ping the volunteers to get the info and add it to the PR before we ship it.
