### PR TITLE
SC-24603 - add installation guide for OpenCode and VS Code Chat

### DIFF
--- a/docs/mcp/getting-started.md
+++ b/docs/mcp/getting-started.md
@@ -128,7 +128,7 @@ By following these steps your VS Code will automatically open generated `mcp.jso
 
     {
     	"servers": {
-    		"sematext-eu": {
+    		"sematext-cloud": {
     			"url": "https://mcp.eu.sematext.com/mcp",
     			"type": "http",
     			"headers": {

--- a/docs/mcp/getting-started.md
+++ b/docs/mcp/getting-started.md
@@ -84,7 +84,7 @@ opencode mcp list
 
 The output should contain this message (example for US account):
 ```
-●  ✓ sematext-us connected
+●  ✓ sematext-cloud connected
 │      https://mcp.sematext.com/mcp
 ```
 

--- a/docs/mcp/getting-started.md
+++ b/docs/mcp/getting-started.md
@@ -37,9 +37,6 @@ If you're on EU, run this command instead:
 claude mcp add --transport http --scope user sematext-cloud https://mcp.eu.sematext.com/mcp --header "Authorization: apiKey xxxx-xx-xx-xxxx"
 ```
 
-
-#### Verifying the installation
-
 Once you have installed the MCP Server, you can verify that it works with the following command:
 ```bash
 claude mcp list
@@ -52,3 +49,96 @@ sematext-cloud: https://mcp.sematext.com/mcp (HTTP) - ✔ Connected
 
 If you see any errors, please check that you have provided the correct API key.
 
+
+### OpenCode
+
+Installing the Sematext Cloud MCP Server for Claude Code is still simple, but requires a bit of tinkering in opensearch config files. 
+
+First, locate and open the `opencode.json` file that you use for OpenCode settings. On various linux distributions it can be found either in `~/.config/opencode/opencode.json` or `~/.opencode/opencode.json`, if current linux user is the one who installed OpenCode.
+
+Under `"mcp"` block add the following content if your Sematext Cloud account is on the US region:
+
+    "sematext-cloud": {
+      "type": "remote",
+      "url": "https://mcp.sematext.com/mcp",
+      "headers": {
+        "Authorization": "apiKey xxxx-xx-xx-xxxx"
+      }
+    }
+
+and if your Sematext Cloud account is on the EU region:
+
+    "sematext-cloud": {
+      "type": "remote",
+      "url": "https://mcp.eu.sematext.com/mcp",
+      "headers": {
+        "Authorization": "apiKey xxxx-xx-xx-xxxx"
+      }
+    }
+
+Saving the file and reloading/opening OpenCode should install the MCP server, so verify that it works with the following command:
+
+```bash
+opencode mcp list
+```
+
+The output should contain this message (example for US account):
+```
+●  ✓ sematext-us connected
+│      https://mcp.sematext.com/mcp
+```
+
+If you see any errors, please check that you provided the correct API key. If you did and there is still a failure connecting to an MCP server,  there might be a misconfiguration issue or a bug regarding regarding HTTP handler. So instead of "remote MCP server type" instructions mentioned above, put the following content under your `"mcp"` block inside `opencode.json` file:
+
+    "sematext-cloud": {
+      "type": "local",
+      "command": ["npx", "-y", "mcp-remote",
+          "https://mcp.sematext.com/mcp",
+          "--transport", "http-only",
+          "--header", "Authorization: apiKey xxxx-xx-xx-xxxx"
+      ],
+      "enabled": true
+    }
+
+Note: in order for this "local MCP server type" approach to work with Sematext Cloud MCP Server, your machine (under the user you are running OpenCode) should have `nodejs` and `npx` packages installed and accessible.
+
+
+
+### VS Code MCP servers
+
+In order to use Sematext Cloud MCP server via VS Code Chat interface (regardless of an AI model that is currently "powering" your VS Code panel), put the following content into the `mcp.json` file under `"servers"` block that you created by following the [official VS Code instructions](https://code.visualstudio.com/docs/agent-customization/mcp-servers) (US account example):
+
+    		"sematext-cloud": {
+    			"url": "https://mcp.sematext.com/mcp",
+    			"type": "http",
+    			"headers": {
+    				"Authorization": "apiKey xxxx-xx-xx-xxxx"
+    			}
+    		}
+
+If you are unsure which `mcp.json` file to use or you don't have any such file at all, follow these steps:
+1. In VS Code, open `Command Pallete...` (Under `View` tab in uppermost Action Bar)
+2. Type and select `MCP: Add Server...`
+3. Choose `HTTP (HTTP or Server-Sent Events)`
+4. For URL type `https://mcp.sematext.com/mcp`
+5. For MCP server label type `sematext-cloud`
+6. choose `Remote` as a handler
+
+By following these steps your VS Code will automatically open generated `mcp.json` file for you. Make sure that the contents of that file looks like this:
+
+    {
+    	"servers": {
+    		"sematext-eu": {
+    			"url": "https://mcp.eu.sematext.com/mcp",
+    			"type": "http",
+    			"headers": {
+    				"Authorization": "apiKey xxxx-xx-xx-xxxx"
+    			}
+    		}
+    	},
+    	"inputs": []
+    }
+
+Finally, start the MCP server: one way to do it is to click on "Start" option that is shown above MCP server's name (in your case, `sematext-cloud`) inside `mcp.json` file.
+
+If you are presented with a pop-up message titled "Dynamic Client Registration not supported", do not proceed or add OAuth client id information - select "Cancel" or press ESC key. Instead, check if your `mcp.json` file contents are actually saved and if you have provided the correct API key, then try again starting the server.

--- a/docs/mcp/getting-started.md
+++ b/docs/mcp/getting-started.md
@@ -1,7 +1,7 @@
 title: Getting Started
-description: Installation instructions for the Sematext Cloud MCP Server
+description: Installation instructions for the Sematext MCP Server
 
-Installing the Sematext Cloud MCP Server is fairly simple, with the setup varying based on which AI agent provider you use. This page contains guides on how to install it with various providers.
+Installing the Sematext MCP Server is fairly simple, with the setup varying based on which AI agent provider you use. This page contains guides on how to install it with various providers.
 
 
 
@@ -23,15 +23,15 @@ This section contains the setup guides for different agent providers.
 
 ### Claude Code
 
-Installing the Sematext Cloud MCP Server for Claude Code is super simple - it can be done with a single command! Just make sure to replace the `apiKey` here with your real API Key.
+Installing the Sematext MCP Server for Claude Code is super simple - it can be done with a single command! Just make sure to replace the `apiKey` here with your real API Key.
 
-If your account is on the US region, run this command:
+If your account is in the US region, run this command:
 
 ```bash
 claude mcp add --transport http --scope user sematext-cloud https://mcp.sematext.com/mcp --header "Authorization: apiKey xxxx-xx-xx-xxxx"
 ```
 
-If you're on EU, run this command instead:
+If you're in EU, run this command instead:
 
 ```bash
 claude mcp add --transport http --scope user sematext-cloud https://mcp.eu.sematext.com/mcp --header "Authorization: apiKey xxxx-xx-xx-xxxx"
@@ -52,11 +52,11 @@ If you see any errors, please check that you have provided the correct API key.
 
 ### OpenCode
 
-Installing the Sematext Cloud MCP Server for Claude Code is still simple, but requires a bit of tinkering in opensearch config files. 
+Installing the Sematext MCP Server for OpenCode is still simple, but requires a bit of tinkering in the OpenCode config file. 
 
-First, locate and open the `opencode.json` file that you use for OpenCode settings. On various linux distributions it can be found either in `~/.config/opencode/opencode.json` or `~/.opencode/opencode.json`, if current linux user is the one who installed OpenCode.
+First, locate and open the `opencode.json` file that you use for OpenCode settings. On various linux distributions (WSL included) it can be found either in `~/.config/opencode/opencode.json` or `~/.opencode/opencode.json`, if current linux user is the one who installed OpenCode.
 
-Under `"mcp"` block add the following content if your Sematext Cloud account is on the US region:
+Under `"mcp"` block add the following content if your Sematext Cloud account is in the US region:
 
     "sematext-cloud": {
       "type": "remote",
@@ -66,7 +66,7 @@ Under `"mcp"` block add the following content if your Sematext Cloud account is 
       }
     }
 
-and if your Sematext Cloud account is on the EU region:
+and if your Sematext Cloud account is in the EU region:
 
     "sematext-cloud": {
       "type": "remote",
@@ -76,7 +76,7 @@ and if your Sematext Cloud account is on the EU region:
       }
     }
 
-Saving the file and reloading/opening OpenCode should install the MCP server, so verify that it works with the following command:
+Saving the file and reloading/opening OpenCode should install the Sematext MCP server, so verify that it works with the following command:
 
 ```bash
 opencode mcp list
@@ -88,7 +88,7 @@ The output should contain this message (example for US account):
 │      https://mcp.sematext.com/mcp
 ```
 
-If you see any errors, please check that you provided the correct API key. If you did and there is still a failure connecting to an MCP server,  there might be a misconfiguration issue or a bug regarding regarding HTTP handler. So instead of "remote MCP server type" instructions mentioned above, put the following content under your `"mcp"` block inside `opencode.json` file:
+If you see any errors, please check that you provided the correct Sematext Cloud API key. If you did and there is still a failure connecting to an MCP server, there might be a misconfiguration issue or a bug regarding regarding HTTP handler. So instead of "remote MCP server type" instructions mentioned above, put the following content under your `"mcp"` block inside `opencode.json` file:
 
     "sematext-cloud": {
       "type": "local",
@@ -100,13 +100,13 @@ If you see any errors, please check that you provided the correct API key. If yo
       "enabled": true
     }
 
-Note: in order for this "local MCP server type" approach to work with Sematext Cloud MCP Server, your machine (under the user you are running OpenCode) should have `nodejs` and `npx` packages installed and accessible.
+Note: in order for this "local MCP server type" approach to work with Sematext MCP Server, your machine (under the user you are running OpenCode) should have `nodejs` and `npx` packages installed and accessible.
 
 
 
-### VS Code MCP servers
+### Visual Studio Code MCP servers
 
-In order to use Sematext Cloud MCP server via VS Code Chat interface (regardless of an AI model that is currently "powering" your VS Code panel), put the following content into the `mcp.json` file under `"servers"` block that you created by following the [official VS Code instructions](https://code.visualstudio.com/docs/agent-customization/mcp-servers) (US account example):
+In order to use Sematext MCP server via VS Code Chat interface (regardless of an AI model that is currently "powering" your VS Code panel), put the following content into the `mcp.json` file under `"servers"` block that you created by following the [official VS Code instructions](https://code.visualstudio.com/docs/agent-customization/mcp-servers) (US account example):
 
     		"sematext-cloud": {
     			"url": "https://mcp.sematext.com/mcp",
@@ -124,7 +124,7 @@ If you are unsure which `mcp.json` file to use or you don't have any such file a
 5. For MCP server label type `sematext-cloud`
 6. choose `Remote` as a handler
 
-By following these steps your VS Code will automatically open generated `mcp.json` file for you. Make sure that the contents of that file looks like this:
+By following these steps your VS Code will automatically open the generated `mcp.json` file for you. Make sure that the contents of that file looks like this:
 
     {
     	"servers": {
@@ -141,4 +141,4 @@ By following these steps your VS Code will automatically open generated `mcp.jso
 
 Finally, start the MCP server: one way to do it is to click on "Start" option that is shown above MCP server's name (in your case, `sematext-cloud`) inside `mcp.json` file.
 
-If you are presented with a pop-up message titled "Dynamic Client Registration not supported", do not proceed or add OAuth client id information - select "Cancel" or press ESC key. Instead, check if your `mcp.json` file contents are actually saved and if you have provided the correct API key, then try again starting the server.
+If you are presented with a pop-up message titled "Dynamic Client Registration not supported", do not proceed or add OAuth client id information - select "Cancel" or press ESC key. Instead, check if your `mcp.json` file content is actually saved and if you have provided the correct API key, then try starting the server again.


### PR DESCRIPTION
I wasted too much time on Cline instructions so I gave up. Apparently Cline VSC extension broke my VSC last time and it almost broke now, there seems to be a bug that overrides Authentication header with OAuth clientID.

So yeah, only OpenCode and VSC Chat, but I really think this is more than enough, along with instructions for Claude from Haris and Codex from Akshat