### PR TITLE
[SC-25043] docs(logs): document RE2 masking pattern syntax and CEL script field

### DIFF
--- a/docs/logs/field-masking-processor.md
+++ b/docs/logs/field-masking-processor.md
@@ -1,5 +1,5 @@
 title: Field Masking Processor
-description: Mask fields using a regex pattern.
+description: Mask fields using an RE2 regular expression pattern.
 
 The Field Masking Processor enables the masking of specific sections within text fields using regex patterns. This processor is ideal for safeguarding sensitive data, including credit card details, social security numbers, and more. Additionally, sensitive information can also be dropped altogether using various processors available in Logs Pipelines. Check out [Handle Sensitive Data](/docs/logs/handle-sensitive-data-with-pipelines) for additional information.
 
@@ -10,4 +10,22 @@ Field Masking Processor provides a bunch of predefined patterns you may use for 
 Upon selecting the source field and entering the regex pattern, note that we promptly showcase both the original and the new value of the field just below the pattern box. This immediate display allows you to effortlessly track the results of the regex pattern as you type.
 
 ![Processor Field Masking Showcase](/docs/images/logs/pipelines/masking-showcase.png)
+
+## Pattern Syntax
+
+Masking patterns use [RE2 syntax](https://github.com/google/re2/wiki/Syntax). RE2 guarantees that every pattern runs in linear time, so a masking pattern can never slow down or stall log ingestion.
+
+Common regex features work as expected: literals, character classes, quantifiers (`*`, `+`, `?`, `{n,m}`), alternation, anchors (`^`, `$`, `\A`, `\z`, `\b`), capturing and non-capturing groups, named groups `(?<name>...)`, inline flags `(?i)`, `(?m)`, `(?s)`, and Unicode classes such as `\p{L}` or `\p{Greek}`.
+
+The following Perl and Java extensions are not part of RE2 and do not compile:
+
+- Lookahead and lookbehind: `(?=...)`, `(?!...)`, `(?<=...)`, `(?<!...)`
+- Backreferences: `\1` … `\9`, `\k<name>`
+- Possessive quantifiers and atomic groups: `a*+`, `a++`, `(?>...)`
+- Character class union and intersection: `[a[bc]]`, `[a-z&&[^b]]`
+- Java-specific escapes, flags, and classes: `\Z`, `\G`, `\h`, `\H`, `\V`, `\R`, `(?x)`, `(?d)`, `(?u)`, `\p{Alpha}`, `\p{javaLowerCase}`
+
+A pattern that does not compile is shown as an error in the pipeline builder preview. During ingestion such a processor is skipped: log events keep flowing through the rest of the pipeline, but **without this masking applied**, until the pattern is fixed.
+
+The entire match is masked, not a capture group. To keep part of the matched text visible, use the prefix or suffix masking options. Patterns that used lookaround can usually be rewritten as a more specific direct match — for example, instead of `(?<=password=)[^ ]*`, match `password=([^ ]*)` and keep the `password=` prefix visible with the prefix option.
 

--- a/docs/logs/field-masking-processor.md
+++ b/docs/logs/field-masking-processor.md
@@ -27,5 +27,5 @@ The following Perl and Java extensions are not part of RE2 and do not compile:
 
 A pattern that does not compile is shown as an error in the pipeline builder preview. During ingestion such a processor is skipped: log events keep flowing through the rest of the pipeline, but **without this masking applied**, until the pattern is fixed.
 
-The entire match is masked, not a capture group. To keep part of the matched text visible, use the prefix or suffix masking options. Patterns that used lookaround can usually be rewritten as a more specific direct match — for example, instead of `(?<=password=)[^ ]*`, match `password=([^ ]*)` and keep the `password=` prefix visible with the prefix option.
+The entire match is masked, not a capture group. To keep part of the matched text visible, use the prefix or suffix masking options. Patterns that use lookaround can usually be rewritten as a more specific direct match — for example, instead of `(?<=password=)[^ ]*`, match `password=([^ ]*)` and keep the `password=` prefix visible with the prefix option.
 

--- a/docs/logs/processors-overview.md
+++ b/docs/logs/processors-overview.md
@@ -1,5 +1,5 @@
 title: Processors
-description: Add or change a field using a script
+description: Overview of Processors available in Logs Pipelines
 
 Processors are units of processing in Pipelines. They can change, drop, or even produce additional events. They are chained to form a Pipeline. The output of one Processor is the input for the next Processor.
 
@@ -14,8 +14,8 @@ Processors available in Logs Pipelines are:
 - **Rename Fields Processor**: Change the names of log event fields.
 - **Remove Fields Processor**: Remove fields that contain [sensitive information](/docs/logs/handle-sensitive-data-with-pipelines) or redundant data to save from costs. See [Reducing Log Monitoring Costs](/docs/logs/reduce-costs-with-pipelines) for more information.
 - [**Field Extractor Processor**](/docs/logs/field-extractor-processor): Extract fields using a grok pattern.
-- [**Field Masking Processor**](/docs/logs/field-masking-processor): Mask fields using a regex pattern and hide sensitive data. See [Handle Sensitive Data](/docs/logs/handle-sensitive-data-with-pipelines) for more information.
-- [**Script Field Processor**](/docs/logs/script-field-processor): Add or change a field using a script.
+- [**Field Masking Processor**](/docs/logs/field-masking-processor): Mask fields using an [RE2](https://github.com/google/re2/wiki/Syntax) regular expression and hide sensitive data. See [Handle Sensitive Data](/docs/logs/handle-sensitive-data-with-pipelines) for more information.
+- [**Script Field Processor**](/docs/logs/script-field-processor): Add or change a field using a [CEL](https://cel.dev/) expression.
 - [**Sampling Processor**](/docs/logs/sampling-processor): Keep only a certain percentage of your data using random sampling.
 - **Geo Processor**: Enrich log events with reverse geocoding location or IP address.
 


### PR DESCRIPTION
## Why

Logs Pipeline execution moved from the Java consumer to Go (SC-25043). Two processors now behave differently in a user-visible way:

- **Field Masking Processor**: patterns are compiled with Go's RE2 engine. RE2 guarantees linear-time matching (a user pattern can no longer stall ingestion), but it rejects Perl/Java extensions that the old Java engine accepted — lookahead/lookbehind, backreferences, possessive quantifiers, atomic groups, class intersections, and Java-specific escapes/flags. Patterns using them fail to build and the processor is skipped at ingestion.
- **Script Field Processor**: scripts are CEL expressions (SC-25388). The detail page is rewritten in #730; this PR only aligns the overview page's one-line description.

## What changed

- `docs/logs/field-masking-processor.md`: new **Pattern Syntax** reference section — RE2 link, what works, the exact list of constructs that no longer compile, what happens when a pattern doesn't compile (builder preview error; processor skipped at ingestion **without masking applied**), whole-match masking semantics, and how to rewrite lookaround patterns (specific pattern + exclude filter).
- `docs/logs/processors-overview.md`: masking entry says RE2 (with syntax link), script field entry says CEL (with cel.dev link, matching #730 wording), and the page `description:` no longer claims this page is about scripts (was copy-pasted from the script page).

The unsupported-construct list is verified against the engine (each construct compile-tested on Go 1.24 `regexp`), not transcribed from RE2 docs.

Related: #730 (Script Field detail page, no file overlap).