### PR TITLE
SC-24603 Add MCPS docs links

### DIFF
--- a/docs/alerts/alert-events.md
+++ b/docs/alerts/alert-events.md
@@ -7,6 +7,8 @@ Alert events are critical indicators that inform you when certain conditions wit
 
 In the **Alerts** page ([US](https://apps.sematext.com/ui/alerts/events) or [EU](https://apps.eu.sematext.com/ui/alerts/events)), you can easily observe and analyze triggered alerts. This view includes a 24/7 heatmap, histogram, and a detailed table displaying alerts triggered within the selected time period.
 
+You can also have your AI agents analyze your alert events using the [Sematext Cloud MCP Server](/docs/mcp/index).
+
 ### Visualizations
 
 - **Heatmap:** Offers a quick visual representation of alert frequency over time, allowing you to identify patterns at a glance.

--- a/docs/events/correlation.md
+++ b/docs/events/correlation.md
@@ -1,7 +1,7 @@
 title: Correlating Events with Performance Metrics and Logs
 description: Split Screen is product-wide correlation and data-pivoting feature. With Split Screen you can compare Events report with any other report or dashboard, even with Events report but with different filters in the two different screens
 
-Events can be correlated with other data in Sematext using our [Split Screen](/docs/guide/split-screen) feature. When you send meaningful events to Sematext, this sort of correlation aids and speeds up troubleshooting.
+Events can be correlated with other data in Sematext using our [Split Screen](/docs/guide/split-screen) feature, or you can have your AI agents do it with the [Sematext Cloud MCP Server](/docs/mcp/index). When you send meaningful events to Sematext, this sort of correlation aids and speeds up troubleshooting.
 
 ## Correlation with Metrics, Logs, User Experience, and Synthetic Monitors.
 With [Split Screen](/docs/guide/split-screen) you can compare and correlate events with any [Monitoring](/docs/monitoring/), [Logs](/docs/logs/), [Infrastructure](/docs/monitoring/infrastructure/) or [Experience](/docs/experience/) report. Correlation is also possible with [Synthetic Monitors](/docs/synthetics/). It can be used to correlate even with Events report but with different filters in the two different screens. 

--- a/docs/guide/alerts-guide.md
+++ b/docs/guide/alerts-guide.md
@@ -64,4 +64,6 @@ You can view all the default and custom Alerts on the [Alert Rules](https://apps
 
 ![Sematext Cloud Alerts Rules Window](https://sematext.com/docs/images/guide/alerts-and-events/alert-rules-window.png "Sematext Cloud Alerts Rules Window")
 
+You can also have your preferred AI agent review your alerts and how frequently they trigger via the [Sematext Cloud MCP Server](/docs/mcp/index).
+
 More detailed instructions are provided in [Alerts Rules Overview](/docs/alerts/alert-rules).

--- a/docs/integration/ai-agents.md
+++ b/docs/integration/ai-agents.md
@@ -1,0 +1,5 @@
+title: AI Agent Integration
+description: Integrating Sematext Cloud with your AI Agents to quickly find patterns and correlate multiple data points.
+
+
+While Sematext Cloud provides the tools to correlate your data within its UI using features such as [Split Screen](/docs/guide/split-screen) or [Dashboards](/docs/guide/dashboards-guide), you can also give your AI agents access to the data you ship to Sematext Cloud via the [MCP Server](/docs/mcp/index) we provide.

--- a/docs/monitoring/correlation.md
+++ b/docs/monitoring/correlation.md
@@ -3,7 +3,7 @@ description: How to use Split screen to correlate performance metrics with any o
 
 ## Why and When to Correlate Performance Metrics
 
-Correlating performance metrics is a great way to troubleshoot faster than with traditional monitoring tools.
+Correlating performance metrics is a great way to troubleshoot faster than with traditional monitoring tools. Correlation can be performed manually via the Sematext Cloud UI, or with your AI agent of choice using the [Sematext Cloud MCP Server](/docs/mcp/index).
 
 ## What to Correlate
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -219,6 +219,7 @@ nav:
       - FAQ: synthetics/faq.md
     - Integrations:
       - Overview: integration/index.md
+      - AI Agents: integration/ai-agents.md
       - Servers, Containers & Orchestration:
         - Infra: integration/infra.md
         - Kubernetes: integration/kubernetes.md


### PR DESCRIPTION
This PR adds links to the MCP Server docs to existing docs pages, as well as adding a new `AI Agents` page to integrations for visibility.