### PR TITLE
[SC-25596] docs(agent): add 4.4.1 release notes

### DIFF
--- a/docs/agents/sematext-agent/releasenotes.md
+++ b/docs/agents/sematext-agent/releasenotes.md
@@ -39,6 +39,18 @@ NULL
 
 -->
 
+## Version 4.4.1
+
+Date: July 21, 2026
+
+### Improvements
+
+- **Network Map Disk I/O on Standalone Hosts**: Disk I/O rates for services on standalone (non-Kubernetes) hosts are now read from the service's cgroup instead of individual processes, so services show real disk read and write rates in Network Map. Previously these values often appeared as zero.
+
+### Bug Fixes
+
+- Network Map connections no longer intermittently lose their protocol label. The periodic connection scan could re-report an already-classified connection as unclassified, causing edges with HTTP status codes to show a blank or Unknown protocol.
+
 ## Version 4.4.0
 
 Date: July 13, 2026

--- a/docs/agents/sematext-agent/releasenotes.md
+++ b/docs/agents/sematext-agent/releasenotes.md
@@ -43,12 +43,9 @@ NULL
 
 Date: July 21, 2026
 
-### Improvements
-
-- **Network Map Disk I/O on Standalone Hosts**: Disk I/O rates for services on standalone (non-Kubernetes) hosts are now read from the service's cgroup instead of individual processes, so services show real disk read and write rates in Network Map. Previously these values often appeared as zero.
-
 ### Bug Fixes
 
+- Disk I/O rates for services on standalone (non-Kubernetes) hosts no longer show as zero in Network Map. They are now read from the service's cgroup instead of individual processes.
 - Network Map connections no longer intermittently lose their protocol label. The periodic connection scan could re-report an already-classified connection as unclassified, causing edges with HTTP status codes to show a blank or Unknown protocol.
 
 ## Version 4.4.0


### PR DESCRIPTION
Two user-facing changes shipped in it:
1. Network Map disk I/O for services on standalone hosts is now read from the service's cgroup instead of individual processes; values that previously showed zero now report real read/write rates.
2. The periodic connection scan no longer overwrites an already-classified connection's protocol, fixing edges that carried HTTP status codes but showed a blank or Unknown protocol label.